### PR TITLE
Fix anchor positioning plan: use CSS file instead of inline styles

### DIFF
--- a/thoughts/shared/plans/2025-12-16-design-notes-element-anchoring.md
+++ b/thoughts/shared/plans/2025-12-16-design-notes-element-anchoring.md
@@ -386,6 +386,35 @@ designNotes: {
 
 ---
 
+## Phase 6: Cleanup Unused Code
+
+### Overview
+Remove the unused `DesignNotesPanel` component that was an alternative implementation approach.
+
+### Changes Required:
+
+#### 1. Delete Unused Component
+**File**: `src/components/demos/DesignNotesPanel.tsx` (delete)
+**Reason**: This component is never imported anywhere in the codebase. It appears to be an earlier/alternative approach to design notes with a tabbed interface. The `InlineRedlines` component in `AIHighlightsVignette.tsx` is the actual implementation being used.
+
+**Verification before deletion:**
+```bash
+# Confirm no imports exist
+grep -r "DesignNotesPanel" src/
+# Should only show the file itself, no imports
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] TypeScript compilation passes: `npm run build`
+- [ ] No broken imports: `npm run dev`
+
+#### Manual Verification:
+- [ ] N/A (removing unused code)
+
+---
+
 ## Testing Strategy
 
 ### Manual Testing Steps:


### PR DESCRIPTION
The original plan used inline styles with anchor() functions, which
causes top-left clustering because React passes these as literal
strings that browsers can't parse as CSS functions.

Updated approach:
- CSS file for anchor() positioning rules (parsed by CSS engine)
- Inline styles only for position-anchor (simple values work)
- Data attributes for position variants
- Added troubleshooting section and browser support matrix