### PR TITLE
Add redline mode for design annotations

### DIFF
--- a/.claude/commands/research_design_patterns.md
+++ b/.claude/commands/research_design_patterns.md
@@ -1,0 +1,180 @@
+---
+description: Research UX patterns comprehensively with web research and concrete recommendations
+---
+
+# Research Design Patterns
+
+You are tasked with conducting comprehensive UX pattern research to answer design questions by searching the web, analyzing patterns, and providing actionable recommendations.
+
+## Initial Setup:
+
+When this command is invoked, respond with:
+```
+I'm ready to research UX patterns. Describe your design challenge, and I'll explore patterns, check what's already in your codebase, and give you a concrete recommendation.
+```
+
+Then wait for the user's design question.
+
+## Steps to follow after receiving the design question:
+
+1. **Gather constraints before researching:**
+   - Ask clarifying questions if needed:
+     - What's the core interaction problem?
+     - What platform/context? (mobile, desktop, responsive)
+     - What are the hard constraints? (framework, performance budget, a11y requirements)
+     - What matters most? (polish vs. speed, novel vs. conventional, etc.)
+   - If the user has already provided sufficient context, proceed directly
+
+2. **Quick codebase pattern discovery (optional):**
+   - Scan for similar patterns already implemented in the codebase
+   - Check available primitives (animations, components, utilities)
+   - Reference: `CLAUDE.md`, `src/lib/`, `src/components/`
+   - Note: Skip or abbreviate if no relevant patterns exist - this is helpful context, not a requirement
+
+3. **Conduct targeted web research:**
+   - Run 3-5 parallel WebSearch queries covering:
+     - Implementations and real examples (not generic definitions)
+     - Design system approaches (Material Design, Apple HIG, Radix UI, shadcn/ui)
+     - Real-world examples (Mobbin, Page Flows, best-in-class products like Linear, Stripe, Vercel)
+     - Mobile/responsive considerations if relevant
+     - Accessibility and performance implications
+   - Focus on "how do the best products solve this?" not "what is this pattern?"
+
+4. **Synthesize into 2-3 viable options:**
+   - For each option, determine:
+     - Why it works for this specific context
+     - Implementation sketch (pseudo-code or component structure)
+     - Similar patterns in codebase (if any exist)
+     - Effort estimate in hours (be concrete: "3-4h" not "medium")
+     - Gotchas and edge cases to watch for
+
+5. **Make a decisive recommendation:**
+   - Lead with: "Given your constraints, I'd do X because..."
+   - Tie rationale to specific constraints the user mentioned
+   - Suggest what to try first (smallest viable experiment)
+
+6. **Gather metadata for the research document:**
+   - Get current date: `date -Iseconds`
+   - Get git info: `git rev-parse HEAD && git branch --show-current`
+   - Filename: `thoughts/shared/research/YYYY-MM-DD-[topic]-patterns.md`
+     - Format: `YYYY-MM-DD-topic-patterns.md` where:
+       - YYYY-MM-DD is today's date
+       - topic is a brief kebab-case description
+     - Examples:
+       - `2025-12-16-mobile-annotation-patterns.md`
+       - `2025-12-16-bottom-sheet-ux-patterns.md`
+
+7. **Generate research document:**
+   - Use the metadata gathered in step 6
+   - Structure the document with YAML frontmatter followed by content:
+
+     ```markdown
+     ---
+     date: [Current date and time with timezone in ISO format]
+     git_commit: [Current commit hash]
+     branch: [Current branch name]
+     repository: [Repository name]
+     topic: "[User's Design Question]"
+     tags: [research, ux-patterns, relevant-component-names]
+     status: complete
+     last_updated: [Current date in YYYY-MM-DD format]
+     last_updated_by: claude
+     ---
+
+     # Research: [User's Design Question]
+
+     [Summary of the user's design question]
+
+     ## Recommendation
+
+     [One paragraph: what I'd do and why, given your constraints. Be decisive, not hedged.]
+
+     ## Quick Comparison
+
+     | Option | A11y | Uses Existing | Risk | Verdict |
+     |--------|------|---------------|------|---------|
+     | A      |  ✓   | Framer ✓      | Low  | **Recommended** |
+     | B      | 2h   | ~    | New primitive | Med  | Quick fallback |
+     | C      | 6-8h | ✓    | Custom        | High | Skip unless polish critical |
+
+     ## Constraints Considered
+
+     - **Stack**: [What's available - React, Framer Motion, etc.]
+     - **Existing patterns**: [What's already built that's similar, or "None directly applicable"]
+     - **Priority**: [What matters most - speed, polish, a11y, etc.]
+
+     ## Option A: [Name] (Recommended)
+
+     ### Why this works
+     [2-3 sentences connecting to constraints]
+
+     ### Implementation sketch
+     ```tsx
+     // Rough approach showing component structure
+     ```
+
+     ### Similar to in codebase (if applicable)
+     [Link to existing pattern - omit section if none]
+
+
+     ### Gotchas
+     - [Specific issue to watch for]
+     - [Browser/device consideration]
+
+     ## Option B: [Name]
+
+     [Same structure, can be shorter]
+
+     ## What I Ruled Out
+
+     - **[Pattern X]**: [One line why - e.g., "Too complex for the payoff"]
+     - **[Pattern Y]**: [One line why - e.g., "Doesn't work on mobile Safari"]
+
+     ## Sources
+
+     - [Title](URL) - [one line on what's useful here]
+     ```
+
+8. **Present findings and handle follow-ups:**
+   - Present a concise summary with your recommendation
+   - Ask if they want to explore any option further
+   - If the user has follow-up questions, append to the same research document:
+     - Add `## Follow-up: [topic]` section
+     - Update frontmatter `last_updated` field
+
+## Important notes:
+
+- **Be decisive**: Lead with a recommendation, not a menu of equal options
+- **Be concrete**: Hours not "complexity", specific gotchas not vague considerations
+- **Be practical**: Implementation sketches show you've thought through the approach
+- **Focus on implementations**: Skip generic pattern definitions - find how real products solve this
+- **Cite sources**: Every claim should link to where you found it
+- **Know when to stop**: 2-3 good options is better than 6 superficial ones
+
+## Key sources to search:
+
+**For pattern research:**
+- Mobbin - real app screenshots and flows
+- Page Flows - user journey recordings
+- NN/g (Nielsen Norman Group) - research-backed guidelines
+- Smashing Magazine - in-depth UX articles
+
+**For implementation reference:**
+- Radix UI - accessibility-first primitives
+- shadcn/ui - modern React patterns with code
+- Material Design 3 - comprehensive component specs
+- Apple Human Interface Guidelines - platform conventions
+
+**For inspiration:**
+- Linear, Vercel, Stripe - best-in-class web products
+- Awwwards - creative implementations
+- Native platform examples (iOS Settings, Apple Maps, etc.)
+
+## Output quality checklist:
+
+- [ ] Recommendation is decisive and at the top
+- [ ] Effort estimates are in hours, not abstract levels
+- [ ] Implementation sketches show component structure
+- [ ] Gotchas are specific, not generic warnings
+- [ ] Sources are linked with brief descriptions of what's useful
+- [ ] Ruled-out patterns have one-line dismissal rationale

--- a/src/components/vignettes/ai-highlights/AIHighlightsVignette.tsx
+++ b/src/components/vignettes/ai-highlights/AIHighlightsVignette.tsx
@@ -35,9 +35,9 @@ function InlineRedlines({
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.3, ease: 'easeOut' }}
           >
-            <div className={`flex items-start gap-3 ${alignRight ? 'flex-row-reverse text-right' : 'text-left'}`}>
+            <div className={`flex items-start ${alignRight ?  'text-left' : 'flex-row-reverse text-right' }`}>
               {/* Dot and line */}
-              <div className={`flex items-center ${alignRight ? 'flex-row-reverse' : ''}`}>
+              <div className={`flex items-center pt-4 ${alignRight ? '' : 'flex-row-reverse' }`}>
                 <div
                   className="w-2.5 h-2.5 rounded-full"
                   style={{
@@ -46,14 +46,14 @@ function InlineRedlines({
                   }}
                 />
                 <div
-                  className={`h-px w-10 ${alignRight ? 'mr-2' : 'ml-2'}`}
+                  className={`h-px w-8 ${alignRight ? 'mr-2' : 'ml-2'}`}
                   style={{ backgroundColor: accent }}
                 />
               </div>
 
               {/* Label box */}
               <div
-                className="rounded-xl px-3 py-2 shadow-sm max-w-[230px] bg-white"
+                className="rounded-xl px-3 py-2 shadow-sm min-w-[230px] bg-white"
                 style={{
                   border: `1px solid ${accent}33`,
                   boxShadow: '0 12px 40px rgba(248, 113, 113, 0.15)'

--- a/src/components/vignettes/ai-highlights/AIHighlightsVignette.tsx
+++ b/src/components/vignettes/ai-highlights/AIHighlightsVignette.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import HighlightsPanel from './HighlightsPanel';
 import VignetteContainer from '@/components/vignettes/VignetteContainer';
@@ -9,83 +9,30 @@ import VignetteStaged, { useVignetteStage } from '@/components/vignettes/Vignett
 import { fadeInUp } from '@/lib/animations';
 import { aiHighlightsContent } from './content';
 import type { DesignNote } from '@/components/vignettes/types';
+import { useRedlineMode } from '@/components/vignettes/shared/useRedlineMode';
+import RedlineOverlay from '@/components/vignettes/shared/RedlineOverlay';
+import MobileRedlineTour from '@/components/vignettes/shared/MobileRedlineTour';
+import MobileRedlineMarkers from '@/components/vignettes/shared/MobileRedlineMarkers';
+import { useReducedMotion } from '@/lib/useReducedMotion';
+import { redlineAnimations, redlineAnimationsReduced } from '@/lib/redline-animations';
 import './design-notes.css';
 
-function InlineRedlines({
-  notes,
-  accent
-}: {
-  notes: DesignNote[];
-  accent: string;
-}) {
-  return (
-    <div className="pointer-events-none" style={{ overflow: 'visible' }}>
-      {notes.map((note) => {
-        const alignRight = note.position === 'right';
-
-        return (
-          <motion.div
-            key={note.id}
-            className="design-note"
-            data-position={note.position}
-            style={{
-              positionAnchor: `--${note.anchor}`,
-            } as React.CSSProperties}
-            initial={{ opacity: 0, y: 6 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.3, ease: 'easeOut' }}
-          >
-            <div className={`flex items-start ${alignRight ?  'text-left' : 'flex-row-reverse text-right' }`}>
-              {/* Dot and line */}
-              <div className={`flex items-center pt-4 ${alignRight ? '' : 'flex-row-reverse' }`}>
-                <div
-                  className="w-2.5 h-2.5 rounded-full"
-                  style={{
-                    backgroundColor: accent,
-                    boxShadow: `0 0 0 8px ${accent}1a`
-                  }}
-                />
-                <div
-                  className={`h-px w-8 ${alignRight ? 'mr-2' : 'ml-2'}`}
-                  style={{ backgroundColor: accent }}
-                />
-              </div>
-
-              {/* Label box */}
-              <div
-                className="rounded-xl px-3 py-2 shadow-sm min-w-[230px] bg-white"
-                style={{
-                  border: `1px solid ${accent}33`,
-                  boxShadow: '0 12px 40px rgba(248, 113, 113, 0.15)'
-                }}
-              >
-                <p className="text-[13px] font-semibold leading-[1.3]" style={{ color: accent }}>
-                  {note.label}
-                </p>
-                <p className="text-[13px] leading-[1.5] mt-1 text-[#475569]">
-                  {note.detail}
-                </p>
-              </div>
-            </div>
-          </motion.div>
-        );
-      })}
-    </div>
-  );
-}
-
 function AIHighlightsContent({
-  showDesignNotes,
-  toggleDesignNotes,
   redlineNotes,
-  accent
+  accent,
+  redlineMode,
+  mobileIndex,
+  onMobileIndexChange,
 }: {
-  showDesignNotes: boolean;
-  toggleDesignNotes: () => void;
   redlineNotes: DesignNote[];
   accent: string;
+  redlineMode: ReturnType<typeof useRedlineMode>;
+  mobileIndex: number;
+  onMobileIndexChange: (index: number) => void;
 }) {
   const { stage, goToSolution, setStage } = useVignetteStage();
+  const reducedMotion = useReducedMotion();
+  const animations = reducedMotion ? redlineAnimationsReduced : redlineAnimations;
 
   // Get stage-specific content
   const currentStageContent = stage === 'problem'
@@ -94,7 +41,11 @@ function AIHighlightsContent({
 
   const title = currentStageContent?.title || aiHighlightsContent.title;
   const description = currentStageContent?.description || aiHighlightsContent.description;
-  const showNotesOverlay = stage === 'solution' && showDesignNotes && redlineNotes.length > 0;
+
+  // Map focusedAnnotation to anchor name for HighlightsPanel
+  const focusedAnchor = redlineMode.focusedAnnotation
+    ? redlineNotes.find(n => n.id === redlineMode.focusedAnnotation)?.anchor ?? null
+    : null;
 
   return (
     <VignetteSplit
@@ -153,38 +104,77 @@ function AIHighlightsContent({
       actions={
         stage === 'solution' && (
           <button
-            onClick={toggleDesignNotes}
+            onClick={redlineMode.toggleRedlineMode}
             className="inline-flex items-center gap-2 text-[14px] font-medium text-[#0f172a] px-3 py-2 rounded-lg border border-gray-200 hover:border-gray-300 transition-colors"
             style={{
-              backgroundColor: showDesignNotes ? `${accent}12` : 'white',
-              borderColor: showDesignNotes ? `${accent}50` : undefined,
-              color: showDesignNotes ? '#991b1b' : undefined
+              backgroundColor: redlineMode.isActive ? `${accent}12` : 'white',
+              borderColor: redlineMode.isActive ? `${accent}50` : undefined,
+              color: redlineMode.isActive ? '#991b1b' : undefined
             }}
           >
-            <span className="material-icons-outlined text-[18px]" style={{ color: showDesignNotes ? accent : '#0f172a' }}>
-              {showDesignNotes ? 'close' : 'edit'}
+            <span className="material-icons-outlined text-[18px]" style={{ color: redlineMode.isActive ? accent : '#0f172a' }}>
+              {redlineMode.isActive ? 'close' : 'edit'}
             </span>
-            {showDesignNotes ? 'Hide design details' : 'Show design details'}
+            {redlineMode.isActive ? 'Hide design details' : 'Show design details'}
           </button>
         )
       }
     >
-      <div className="relative" style={{ overflow: 'visible' }}>
+      <motion.div
+        className="relative"
+        style={{ overflow: 'visible' }}
+        animate={redlineMode.isActive ? animations.panelTransform.active : animations.panelTransform.inactive}
+        transition={animations.panelTransform.transition}
+      >
         <HighlightsPanel
           stage={stage}
           onTransition={goToSolution}
           problemCards={aiHighlightsContent.problemCards}
+          redlineModeActive={redlineMode.isActive}
+          focusedAnchor={focusedAnchor}
         />
-        {showNotesOverlay && <InlineRedlines notes={redlineNotes} accent={accent} />}
-      </div>
+        {/* Desktop annotations */}
+        <RedlineOverlay
+          isActive={redlineMode.isActive && stage === 'solution'}
+          notes={redlineNotes}
+          accent={accent}
+          focusedAnnotation={redlineMode.focusedAnnotation}
+          onFocusAnnotation={redlineMode.setFocusedAnnotation}
+        />
+        {/* Mobile markers */}
+        {redlineMode.isActive && stage === 'solution' && (
+          <MobileRedlineMarkers
+            notes={redlineNotes}
+            accent={accent}
+            currentIndex={mobileIndex}
+            onMarkerClick={onMobileIndexChange}
+          />
+        )}
+      </motion.div>
     </VignetteSplit>
   );
 }
 
 export default function AIHighlightsVignette() {
   const designNotes = aiHighlightsContent.designNotes;
-  const [showDesignNotes, setShowDesignNotes] = useState(false);
-  const toggleDesignNotes = () => setShowDesignNotes((prev) => !prev);
+  const redlineMode = useRedlineMode();
+  const [mobileIndex, setMobileIndex] = useState(0);
+
+  const handleExit = () => {
+    redlineMode.exitRedlineMode();
+    setMobileIndex(0);
+  };
+
+  // Scroll the panel to show the anchor element
+  const handleScrollToAnchor = useCallback((anchor: string) => {
+    const element = document.querySelector(`[data-anchor="${anchor}"]`);
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, []);
+
+  const redlineNotes = designNotes?.notes ?? [];
+  const accent = designNotes?.accent ?? '#ef4444';
 
   return (
     <VignetteContainer id="ai-highlights" allowOverflow>
@@ -197,14 +187,26 @@ export default function AIHighlightsVignette() {
             stages={aiHighlightsContent.stages}
           >
             <AIHighlightsContent
-              showDesignNotes={showDesignNotes}
-              toggleDesignNotes={toggleDesignNotes}
-              redlineNotes={designNotes?.notes ?? []}
-              accent={designNotes?.accent ?? '#ef4444'}
+              redlineNotes={redlineNotes}
+              accent={accent}
+              redlineMode={redlineMode}
+              mobileIndex={mobileIndex}
+              onMobileIndexChange={setMobileIndex}
             />
           </VignetteStaged>
         </motion.div>
       </div>
+
+      {/* Mobile bottom sheet tour - rendered at root level for fixed positioning */}
+      <MobileRedlineTour
+        isActive={redlineMode.isActive}
+        notes={redlineNotes}
+        accent={accent}
+        onExit={handleExit}
+        currentIndex={mobileIndex}
+        onIndexChange={setMobileIndex}
+        onScrollToAnchor={handleScrollToAnchor}
+      />
     </VignetteContainer>
   );
 }

--- a/src/components/vignettes/ai-highlights/HighlightsPanel.tsx
+++ b/src/components/vignettes/ai-highlights/HighlightsPanel.tsx
@@ -10,6 +10,8 @@ interface HighlightsPanelProps {
   stage?: VignetteStage;
   onTransition?: () => void;
   problemCards?: FeedbackSource[];
+  redlineModeActive?: boolean;
+  focusedAnchor?: string | null;
 }
 
 // Predefined positions for scattered cards
@@ -156,9 +158,23 @@ function ProblemState({ cards, onTransition }: { cards: FeedbackSource[]; onTran
   );
 }
 
-function SolutionState({ className = '' }: { className?: string }) {
+interface SolutionStateProps {
+  className?: string;
+  redlineModeActive?: boolean;
+  focusedAnchor?: string | null;
+}
+
+function SolutionState({ className = '', redlineModeActive = false, focusedAnchor = null }: SolutionStateProps) {
   const [highlightExpanded, setHighlightExpanded] = useState(false);
   const [opportunityExpanded, setOpportunityExpanded] = useState(false);
+
+  // Helper to compute anchor region styles
+  const getAnchorStyle = (anchorName: string): React.CSSProperties => ({
+    anchorName: `--${anchorName}`,
+    opacity: redlineModeActive && focusedAnchor && focusedAnchor !== anchorName ? 0.4 : 1,
+    boxShadow: focusedAnchor === anchorName ? '0 0 0 2px rgba(239, 68, 68, 0.2)' : 'none',
+    transition: 'opacity 0.3s ease, box-shadow 0.3s ease',
+  } as React.CSSProperties);
 
   return (
     <div
@@ -167,7 +183,8 @@ function SolutionState({ className = '' }: { className?: string }) {
       {/* Header Section */}
       <div
         className="border-b-2 border-[#eaeaec] px-6 py-6"
-        style={{ anchorName: '--highlights-header' } as React.CSSProperties}
+        style={getAnchorStyle('highlights-header')}
+        data-anchor="highlights-header"
       >
         <div className="flex items-center gap-3 mb-2">
           <img
@@ -194,7 +211,8 @@ function SolutionState({ className = '' }: { className?: string }) {
       {/* Highlight Item */}
       <div
         className="border-b-2 border-[#eaeaec]"
-        style={{ anchorName: '--highlight-item' } as React.CSSProperties}
+        style={getAnchorStyle('highlight-item')}
+        data-anchor="highlight-item"
       >
         <div className="px-6 py-8">
           <div className="flex items-start gap-2">
@@ -280,7 +298,8 @@ function SolutionState({ className = '' }: { className?: string }) {
       {/* Opportunity Item */}
       <div
         className="border-b-2 border-[#eaeaec]"
-        style={{ anchorName: '--opportunity-item' } as React.CSSProperties}
+        style={getAnchorStyle('opportunity-item')}
+        data-anchor="opportunity-item"
       >
         <div className="px-6 py-8">
           <div className="flex items-start gap-2">
@@ -366,7 +385,8 @@ function SolutionState({ className = '' }: { className?: string }) {
       {/* Footer with Feedback Buttons */}
       <div
         className="px-6 py-4 flex items-center gap-2"
-        style={{ anchorName: '--feedback-footer' } as React.CSSProperties}
+        style={getAnchorStyle('feedback-footer')}
+        data-anchor="feedback-footer"
       >
         <span className="text-[14px] leading-[18px] text-[#524e56]">
           Is this helpful?
@@ -396,7 +416,9 @@ export default function HighlightsPanel({
   className = '',
   stage = 'solution',
   onTransition,
-  problemCards = []
+  problemCards = [],
+  redlineModeActive = false,
+  focusedAnchor = null
 }: HighlightsPanelProps) {
   // Default problem cards if none provided
   const defaultProblemCards: FeedbackSource[] = [
@@ -430,7 +452,7 @@ export default function HighlightsPanel({
           exit={{ opacity: 0 }}
           transition={{ duration: 0.2 }}
         >
-          <SolutionState className={className} />
+          <SolutionState className={className} redlineModeActive={redlineModeActive} focusedAnchor={focusedAnchor} />
         </motion.div>
       )}
     </AnimatePresence>

--- a/src/components/vignettes/ai-highlights/design-notes.css
+++ b/src/components/vignettes/ai-highlights/design-notes.css
@@ -44,3 +44,53 @@
     translate: -50% -50%;
   }
 }
+
+/* Mobile Design Note Markers */
+.design-note-marker {
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--accent, #ef4444);
+  color: white;
+  font-size: 12px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 10;
+  border: 2px solid white;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+/* Expand tap target */
+.design-note-marker::before {
+  content: '';
+  position: absolute;
+  inset: -10px;
+}
+
+.design-note-marker[data-position="right"] {
+  left: anchor(right);
+  top: anchor(center);
+  translate: 8px -50%;
+}
+
+.design-note-marker[data-position="left"] {
+  right: anchor(left);
+  top: anchor(center);
+  translate: -8px -50%;
+}
+
+@media (min-width: 1024px) {
+  .design-note-marker {
+    display: none;
+  }
+}
+
+@supports not (anchor-name: --test) {
+  .design-note-marker {
+    display: none; /* Hide on unsupported browsers for mobile */
+  }
+}

--- a/src/components/vignettes/shared/MobileRedlineMarkers.tsx
+++ b/src/components/vignettes/shared/MobileRedlineMarkers.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import type { DesignNote } from '@/components/vignettes/types';
+
+interface MobileRedlineMarkersProps {
+  notes: DesignNote[];
+  accent: string;
+  currentIndex: number;
+  onMarkerClick: (index: number) => void;
+}
+
+export default function MobileRedlineMarkers({
+  notes,
+  accent,
+  currentIndex,
+  onMarkerClick,
+}: MobileRedlineMarkersProps) {
+  return (
+    <div className="lg:hidden pointer-events-auto" style={{ overflow: 'visible' }}>
+      {notes.map((note, index) => (
+        <motion.button
+          key={note.id}
+          className="design-note-marker"
+          data-position={note.position}
+          style={{
+            positionAnchor: `--${note.anchor}`,
+            '--accent': accent,
+          } as React.CSSProperties}
+          animate={{
+            scale: currentIndex === index ? 1.2 : 1,
+            boxShadow: currentIndex === index
+              ? `0 0 0 8px ${accent}40`
+              : `0 0 0 4px ${accent}1a`,
+          }}
+          transition={{ duration: 0.2 }}
+          onClick={() => onMarkerClick(index)}
+          aria-label={`Design note ${index + 1}: ${note.label}`}
+        >
+          {index + 1}
+        </motion.button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/vignettes/shared/MobileRedlineTour.tsx
+++ b/src/components/vignettes/shared/MobileRedlineTour.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { motion, AnimatePresence, PanInfo } from 'framer-motion';
+import type { DesignNote } from '@/components/vignettes/types';
+
+interface MobileRedlineTourProps {
+  isActive: boolean;
+  notes: DesignNote[];
+  accent: string;
+  onExit: () => void;
+  currentIndex: number;
+  onIndexChange: (index: number) => void;
+  onScrollToAnchor?: (anchor: string) => void;
+}
+
+export default function MobileRedlineTour({
+  isActive,
+  notes,
+  accent,
+  onExit,
+  currentIndex,
+  onIndexChange,
+  onScrollToAnchor,
+}: MobileRedlineTourProps) {
+  // Track previous index for direction calculation
+  const prevIndexRef = useRef(currentIndex);
+
+  // Calculate direction based on index change (computed at render time)
+  const direction = currentIndex >= prevIndexRef.current ? 'right' : 'left';
+
+  // Update ref after render and scroll to anchor
+  useEffect(() => {
+    prevIndexRef.current = currentIndex;
+
+    // Scroll to the anchor when index changes
+    const currentNote = notes[currentIndex];
+    if (currentNote && onScrollToAnchor) {
+      onScrollToAnchor(currentNote.anchor);
+    }
+  }, [currentIndex, notes, onScrollToAnchor]);
+
+  const handleDragEnd = (_: unknown, info: PanInfo) => {
+    const threshold = 50;
+    if (info.offset.x < -threshold && currentIndex < notes.length - 1) {
+      onIndexChange(currentIndex + 1);
+    } else if (info.offset.x > threshold && currentIndex > 0) {
+      onIndexChange(currentIndex - 1);
+    } else if (info.offset.y > threshold) {
+      onExit();
+    }
+  };
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!isActive) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case 'Escape':
+          onExit();
+          break;
+        case 'ArrowRight':
+        case 'ArrowDown':
+          if (currentIndex < notes.length - 1) {
+            onIndexChange(currentIndex + 1);
+          }
+          break;
+        case 'ArrowLeft':
+        case 'ArrowUp':
+          if (currentIndex > 0) {
+            onIndexChange(currentIndex - 1);
+          }
+          break;
+        case 'Home':
+          onIndexChange(0);
+          break;
+        case 'End':
+          onIndexChange(notes.length - 1);
+          break;
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isActive, currentIndex, notes.length, onExit, onIndexChange]);
+
+  const currentNote = notes[currentIndex];
+
+  if (!currentNote) return null;
+
+  return (
+    <AnimatePresence>
+      {isActive && (
+        <>
+          {/* Subtle backdrop - tap to dismiss */}
+          <motion.div
+            className="fixed inset-0 z-40 lg:hidden"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onExit}
+          />
+
+          {/* Bottom Sheet */}
+          <motion.div
+            className="fixed inset-x-0 bottom-0 bg-white rounded-t-2xl z-50 lg:hidden"
+            initial={{ y: '100%' }}
+            animate={{ y: 0 }}
+            exit={{ y: '100%' }}
+            transition={{ type: 'spring', damping: 25, stiffness: 300 }}
+            drag="y"
+            dragConstraints={{ top: 0, bottom: 0 }}
+            dragElastic={{ top: 0, bottom: 0.5 }}
+            onDragEnd={handleDragEnd}
+          >
+            {/* Handle */}
+            <div className="flex justify-center pt-3 pb-2">
+              <div className="w-10 h-1 bg-gray-300 rounded-full" />
+            </div>
+
+            {/* Progress */}
+            <div className="px-6 pb-2 flex items-center justify-between">
+              <span className="text-sm text-gray-500">
+                {currentIndex + 1} of {notes.length}
+              </span>
+              <div className="flex gap-1.5">
+                {notes.map((_, i) => (
+                  <button
+                    key={i}
+                    className={`w-2 h-2 rounded-full transition-colors ${
+                      i === currentIndex ? 'bg-gray-900' : 'bg-gray-300'
+                    }`}
+                    onClick={() => onIndexChange(i)}
+                    aria-label={`Go to annotation ${i + 1}`}
+                  />
+                ))}
+              </div>
+            </div>
+
+            {/* Content */}
+            <div className="px-6 pb-8 min-h-[180px]">
+              <AnimatePresence mode="wait">
+                <motion.div
+                  key={currentNote.id}
+                  initial={{ opacity: 0, x: direction === 'right' ? 40 : -40 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: direction === 'right' ? -40 : 40 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  <h3
+                    className="text-lg font-semibold mb-2"
+                    style={{ color: accent }}
+                  >
+                    {currentNote.label}
+                  </h3>
+                  <p className="text-gray-600 leading-relaxed">
+                    {currentNote.detail}
+                  </p>
+                </motion.div>
+              </AnimatePresence>
+            </div>
+
+            {/* Navigation */}
+            <div className="px-6 pb-6 flex gap-3">
+              <button
+                className="flex-1 py-3 px-4 rounded-xl border border-gray-200 text-gray-700 font-medium disabled:opacity-40"
+                onClick={() => onIndexChange(currentIndex - 1)}
+                disabled={currentIndex === 0}
+              >
+                Previous
+              </button>
+              <button
+                className="flex-1 py-3 px-4 rounded-xl font-medium text-white"
+                style={{ backgroundColor: accent }}
+                onClick={() => {
+                  if (currentIndex === notes.length - 1) {
+                    onExit();
+                  } else {
+                    onIndexChange(currentIndex + 1);
+                  }
+                }}
+              >
+                {currentIndex === notes.length - 1 ? 'Done' : 'Next'}
+              </button>
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/vignettes/shared/RedlineOverlay.tsx
+++ b/src/components/vignettes/shared/RedlineOverlay.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { motion, AnimatePresence } from 'framer-motion';
+import type { DesignNote } from '@/components/vignettes/types';
+import { useReducedMotion } from '@/lib/useReducedMotion';
+import { redlineAnimations, redlineAnimationsReduced } from '@/lib/redline-animations';
+
+interface RedlineOverlayProps {
+  isActive: boolean;
+  notes: DesignNote[];
+  accent: string;
+  focusedAnnotation: string | null;
+  onFocusAnnotation: (id: string | null) => void;
+}
+
+export default function RedlineOverlay({
+  isActive,
+  notes,
+  accent,
+  focusedAnnotation,
+  onFocusAnnotation,
+}: RedlineOverlayProps) {
+  const reducedMotion = useReducedMotion();
+  const animations = reducedMotion ? redlineAnimationsReduced : redlineAnimations;
+
+  return (
+    <AnimatePresence>
+      {isActive && (
+        <>
+          {/* Annotations */}
+          <div className="pointer-events-none hidden lg:block" style={{ overflow: 'visible' }}>
+            {notes.map((note, index) => {
+              const alignRight = note.position === 'right';
+              const isFocused = focusedAnnotation === note.id;
+              const isDimmed = focusedAnnotation !== null && !isFocused;
+              const position = note.position === 'right' || note.position === 'left' ? note.position : 'right';
+              const anim = animations.annotation(index, position);
+
+              return (
+                <motion.div
+                  key={note.id}
+                  className="design-note pointer-events-auto cursor-pointer"
+                  data-position={note.position}
+                  style={{
+                    positionAnchor: `--${note.anchor}`,
+                  } as React.CSSProperties}
+                  initial={anim.container.initial}
+                  animate={{
+                    ...anim.container.animate,
+                    opacity: isDimmed ? 0.4 : 1,
+                    scale: isFocused ? 1.02 : 1,
+                  }}
+                  exit={anim.container.exit}
+                  transition={anim.container.transition}
+                  onMouseEnter={() => onFocusAnnotation(note.id)}
+                  onMouseLeave={() => onFocusAnnotation(null)}
+                >
+                  <div className={`flex items-start ${alignRight ? 'text-left' : 'flex-row-reverse text-right'}`}>
+                    {/* Dot and line */}
+                    <div className={`flex items-center pt-4 ${alignRight ? '' : 'flex-row-reverse'}`}>
+                      <motion.div
+                        className="w-2.5 h-2.5 rounded-full"
+                        style={{
+                          backgroundColor: accent,
+                        }}
+                        initial={anim.dot.initial}
+                        animate={{
+                          ...anim.dot.animate,
+                          boxShadow: isFocused
+                            ? `0 0 0 12px ${accent}30`
+                            : `0 0 0 8px ${accent}1a`
+                        }}
+                        transition={anim.dot.transition}
+                      />
+                      <motion.div
+                        className={`h-px w-8 ${alignRight ? 'mr-2' : 'ml-2'}`}
+                        style={{
+                          backgroundColor: accent,
+                          transformOrigin: alignRight ? 'left' : 'right',
+                        }}
+                        initial={anim.connector.initial}
+                        animate={anim.connector.animate}
+                        transition={anim.connector.transition}
+                      />
+                    </div>
+
+                    {/* Label box */}
+                    <motion.div
+                      className="rounded-xl px-3 py-2 shadow-sm min-w-[230px] bg-white"
+                      style={{
+                        border: `1px solid ${accent}33`,
+                      }}
+                      animate={{
+                        boxShadow: isFocused
+                          ? `0 12px 40px ${accent}25`
+                          : '0 12px 40px rgba(248, 113, 113, 0.15)',
+                      }}
+                    >
+                      <p className="text-[13px] font-semibold leading-[1.3]" style={{ color: accent }}>
+                        {note.label}
+                      </p>
+                      <p className="text-[13px] leading-[1.5] mt-1 text-[#475569]">
+                        {note.detail}
+                      </p>
+                    </motion.div>
+                  </div>
+                </motion.div>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/vignettes/shared/useRedlineMode.ts
+++ b/src/components/vignettes/shared/useRedlineMode.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+interface RedlineState {
+  isActive: boolean;
+  focusedAnnotation: string | null;
+}
+
+export function useRedlineMode() {
+  const [state, setState] = useState<RedlineState>({
+    isActive: false,
+    focusedAnnotation: null,
+  });
+
+  const enterRedlineMode = useCallback(() => {
+    setState(prev => ({ ...prev, isActive: true }));
+  }, []);
+
+  const exitRedlineMode = useCallback(() => {
+    setState({ isActive: false, focusedAnnotation: null });
+  }, []);
+
+  const toggleRedlineMode = useCallback(() => {
+    setState(prev => ({
+      isActive: !prev.isActive,
+      focusedAnnotation: null,
+    }));
+  }, []);
+
+  const setFocusedAnnotation = useCallback((id: string | null) => {
+    setState(prev => ({ ...prev, focusedAnnotation: id }));
+  }, []);
+
+  return {
+    ...state,
+    enterRedlineMode,
+    exitRedlineMode,
+    toggleRedlineMode,
+    setFocusedAnnotation,
+  };
+}

--- a/src/lib/redline-animations.ts
+++ b/src/lib/redline-animations.ts
@@ -1,0 +1,72 @@
+import type { Easing } from 'framer-motion';
+
+export const redlineAnimations = {
+  overlay: {
+    initial: { opacity: 0 },
+    animate: { opacity: 1 },
+    exit: { opacity: 0 },
+    transition: { duration: 0.4 },
+  },
+
+  panelTransform: {
+    active: { scale: 0.98 },
+    inactive: { scale: 1 },
+    transition: { duration: 0.4, ease: 'easeOut' as Easing },
+  },
+
+  annotation: (index: number, position: 'left' | 'right') => ({
+    container: {
+      initial: { opacity: 0, x: position === 'right' ? -20 : 20 },
+      animate: { opacity: 1, x: 0 },
+      exit: { opacity: 0, x: position === 'right' ? -20 : 20 },
+      transition: { duration: 0.3, delay: index * 0.1, ease: 'easeOut' as Easing },
+    },
+    connector: {
+      initial: { scaleX: 0 },
+      animate: { scaleX: 1 },
+      transition: { duration: 0.15, delay: index * 0.1 },
+    },
+    dot: {
+      initial: { scale: 0 },
+      animate: { scale: [0, 1.3, 1] },
+      transition: {
+        duration: 0.4,
+        delay: index * 0.1 + 0.15,
+        ease: [0.34, 1.56, 0.64, 1] as [number, number, number, number],
+      },
+    },
+  }),
+};
+
+// Reduced motion variants
+export const redlineAnimationsReduced = {
+  overlay: {
+    initial: { opacity: 0 },
+    animate: { opacity: 1 },
+    exit: { opacity: 0 },
+    transition: { duration: 0.1 },
+  },
+  panelTransform: {
+    active: { scale: 1 },
+    inactive: { scale: 1 },
+    transition: { duration: 0 },
+  },
+  annotation: () => ({
+    container: {
+      initial: { opacity: 0 },
+      animate: { opacity: 1 },
+      exit: { opacity: 0 },
+      transition: { duration: 0.1 },
+    },
+    connector: {
+      initial: { scaleX: 1 },
+      animate: { scaleX: 1 },
+      transition: { duration: 0 },
+    },
+    dot: {
+      initial: { scale: 1 },
+      animate: { scale: 1 },
+      transition: { duration: 0 },
+    },
+  }),
+};

--- a/src/lib/useReducedMotion.ts
+++ b/src/lib/useReducedMotion.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export function useReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const query = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setPrefersReducedMotion(query.matches);
+
+    const handler = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    query.addEventListener('change', handler);
+    return () => query.removeEventListener('change', handler);
+  }, []);
+
+  return prefersReducedMotion;
+}

--- a/thoughts/shared/plans/2025-12-16-mobile-annotation-patterns.md
+++ b/thoughts/shared/plans/2025-12-16-mobile-annotation-patterns.md
@@ -1,0 +1,961 @@
+# Redline Mode Implementation Plan
+
+## Overview
+
+Implement a transformative "Redline Mode" for design annotations that creates a memorable portfolio moment. When toggled, the UI dims non-annotated regions, spotlights anchor points, and reveals annotations with choreographed animations. Mobile uses a bottom sheet tour. The interaction itself demonstrates mastery-level design skill.
+
+## Current State Analysis
+
+### Existing Implementation
+- `InlineRedlines` component in `AIHighlightsVignette.tsx:14-75`
+- CSS anchor positioning via `design-notes.css`
+- 4 design notes anchored to: header, highlight-item, opportunity-item, feedback-footer
+- Toggle button shows/hides annotations
+- No transformation effect, annotations just appear/disappear
+
+### Key Discoveries
+- Framer Motion 12 available with layout animations, stagger utilities
+- `useInView` hook for scroll-triggered animations
+- VignetteStageContext pattern for state management
+- VignetteSplit stacks at lg breakpoint (1024px)
+
+## Desired End State
+
+**Desktop (≥1024px)**:
+- Toggle "Show design details" → UI transforms
+- Panel scales to 96%, non-annotated areas dim to 40% opacity
+- Spotlights appear on 4 anchor regions
+- Annotations animate in sequentially (left/right based on position)
+- Hover any annotation → that region pulses, others dim further
+- Click empty space or toggle → smooth exit
+
+**Mobile (<1024px)**:
+- Toggle → Panel zooms slightly, backdrop dims
+- Bottom sheet slides up with first annotation
+- Swipe left/right to navigate between 4 annotations
+- Progress dots show 1 of 4
+- Current anchor region spotlit, others dimmed
+- Swipe down or "Done" to exit
+
+### Verification
+- Toggle redline mode on desktop → transformation happens smoothly at 60fps
+- All 4 annotations appear in sequence with staggered timing
+- Hover annotation → corresponding UI region highlights
+- On mobile, swipe through all 4 annotations
+- Exit mode → UI returns to normal state
+- Reduced motion users get instant state changes (no animation)
+
+## What We're NOT Doing
+
+- No sound effects (paper rustle, marker squeak) - adds complexity without core value
+- No handwritten fonts - stick with existing typography
+- No "question mode" gamification
+- No annotation relationships/linking between notes
+- No voice intro audio
+- No completion celebration/confetti
+
+## Implementation Approach
+
+Build in phases with a kill switch. Desktop first (proves the concept), then mobile. If desktop transformation isn't smooth by Phase 2, fall back to simpler "annotations visible on toggle" without the transformation effect.
+
+---
+
+## Phase 1: Core Desktop Transformation
+
+### Overview
+Build the foundational redline mode toggle with spotlight/dim effect and basic annotation reveal.
+
+### Changes Required:
+
+#### 1. Create RedlineMode state hook
+**File**: `src/components/vignettes/shared/useRedlineMode.ts`
+
+```typescript
+'use client';
+
+import { useState, useCallback } from 'react';
+
+interface RedlineState {
+  isActive: boolean;
+  focusedAnnotation: string | null;
+}
+
+export function useRedlineMode() {
+  const [state, setState] = useState<RedlineState>({
+    isActive: false,
+    focusedAnnotation: null,
+  });
+
+  const enterRedlineMode = useCallback(() => {
+    setState(prev => ({ ...prev, isActive: true }));
+  }, []);
+
+  const exitRedlineMode = useCallback(() => {
+    setState({ isActive: false, focusedAnnotation: null });
+  }, []);
+
+  const toggleRedlineMode = useCallback(() => {
+    setState(prev => ({
+      isActive: !prev.isActive,
+      focusedAnnotation: null,
+    }));
+  }, []);
+
+  const setFocusedAnnotation = useCallback((id: string | null) => {
+    setState(prev => ({ ...prev, focusedAnnotation: id }));
+  }, []);
+
+  return {
+    ...state,
+    enterRedlineMode,
+    exitRedlineMode,
+    toggleRedlineMode,
+    setFocusedAnnotation,
+  };
+}
+```
+
+#### 2. Create RedlineOverlay component for desktop
+**File**: `src/components/vignettes/shared/RedlineOverlay.tsx`
+
+```tsx
+'use client';
+
+import { motion, AnimatePresence } from 'framer-motion';
+import type { DesignNote } from '@/components/vignettes/types';
+
+interface RedlineOverlayProps {
+  isActive: boolean;
+  notes: DesignNote[];
+  accent: string;
+  focusedAnnotation: string | null;
+  onFocusAnnotation: (id: string | null) => void;
+}
+
+export default function RedlineOverlay({
+  isActive,
+  notes,
+  accent,
+  focusedAnnotation,
+  onFocusAnnotation,
+}: RedlineOverlayProps) {
+  return (
+    <AnimatePresence>
+      {isActive && (
+        <>
+          {/* Dim overlay for non-annotated areas */}
+          <motion.div
+            className="absolute inset-0 bg-gray-900/10 pointer-events-none hidden lg:block"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.4 }}
+          />
+
+          {/* Annotations */}
+          <div className="pointer-events-none hidden lg:block" style={{ overflow: 'visible' }}>
+            {notes.map((note, index) => {
+              const alignRight = note.position === 'right';
+              const isFocused = focusedAnnotation === note.id;
+              const isDimmed = focusedAnnotation !== null && !isFocused;
+
+              return (
+                <motion.div
+                  key={note.id}
+                  className="design-note pointer-events-auto cursor-pointer"
+                  data-position={note.position}
+                  style={{
+                    positionAnchor: `--${note.anchor}`,
+                    opacity: isDimmed ? 0.4 : 1,
+                  } as React.CSSProperties}
+                  initial={{ opacity: 0, x: alignRight ? -20 : 20 }}
+                  animate={{
+                    opacity: isDimmed ? 0.4 : 1,
+                    x: 0,
+                    scale: isFocused ? 1.02 : 1,
+                  }}
+                  exit={{ opacity: 0, x: alignRight ? -20 : 20 }}
+                  transition={{
+                    duration: 0.3,
+                    delay: index * 0.1,
+                    ease: 'easeOut'
+                  }}
+                  onMouseEnter={() => onFocusAnnotation(note.id)}
+                  onMouseLeave={() => onFocusAnnotation(null)}
+                >
+                  <div className={`flex items-start ${alignRight ? 'text-left' : 'flex-row-reverse text-right'}`}>
+                    {/* Dot and line */}
+                    <div className={`flex items-center pt-4 ${alignRight ? '' : 'flex-row-reverse'}`}>
+                      <motion.div
+                        className="w-2.5 h-2.5 rounded-full"
+                        style={{
+                          backgroundColor: accent,
+                        }}
+                        initial={{ scale: 0 }}
+                        animate={{
+                          scale: 1,
+                          boxShadow: isFocused
+                            ? `0 0 0 12px ${accent}30`
+                            : `0 0 0 8px ${accent}1a`
+                        }}
+                        transition={{
+                          duration: 0.4,
+                          delay: index * 0.1 + 0.15,
+                          ease: [0.34, 1.56, 0.64, 1] // Spring
+                        }}
+                      />
+                      <motion.div
+                        className={`h-px w-8 ${alignRight ? 'mr-2' : 'ml-2'}`}
+                        style={{ backgroundColor: accent }}
+                        initial={{ scaleX: 0, transformOrigin: alignRight ? 'left' : 'right' }}
+                        animate={{ scaleX: 1 }}
+                        transition={{ duration: 0.15, delay: index * 0.1 }}
+                      />
+                    </div>
+
+                    {/* Label box */}
+                    <motion.div
+                      className="rounded-xl px-3 py-2 shadow-sm min-w-[230px] bg-white"
+                      style={{
+                        border: `1px solid ${accent}33`,
+                      }}
+                      animate={{
+                        boxShadow: isFocused
+                          ? `0 12px 40px ${accent}25`
+                          : '0 12px 40px rgba(248, 113, 113, 0.15)',
+                      }}
+                    >
+                      <p className="text-[13px] font-semibold leading-[1.3]" style={{ color: accent }}>
+                        {note.label}
+                      </p>
+                      <p className="text-[13px] leading-[1.5] mt-1 text-[#475569]">
+                        {note.detail}
+                      </p>
+                    </motion.div>
+                  </div>
+                </motion.div>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}
+```
+
+#### 3. Add anchor region highlighting
+**File**: `src/components/vignettes/ai-highlights/HighlightsPanel.tsx`
+**Changes**: Add data attributes and conditional styling for spotlight effect
+
+Add to each anchored div (header, highlight-item, opportunity-item, feedback-footer):
+
+```tsx
+// Pass these props to HighlightsPanel
+interface HighlightsPanelProps {
+  // ... existing props
+  redlineModeActive?: boolean;
+  focusedAnchor?: string | null;
+}
+
+// On each anchor div, add transition styling:
+<div
+  className="border-b-2 border-[#eaeaec] px-6 py-6 transition-all duration-300"
+  style={{
+    anchorName: '--highlights-header',
+    opacity: redlineModeActive && focusedAnchor && focusedAnchor !== 'highlights-header' ? 0.4 : 1,
+    boxShadow: focusedAnchor === 'highlights-header' ? '0 0 0 2px rgba(239, 68, 68, 0.2)' : 'none',
+  } as React.CSSProperties}
+  data-anchor="highlights-header"
+>
+```
+
+#### 4. Update AIHighlightsVignette to use redline mode
+**File**: `src/components/vignettes/ai-highlights/AIHighlightsVignette.tsx`
+**Changes**: Replace showDesignNotes state with useRedlineMode, integrate RedlineOverlay
+
+```tsx
+import { useRedlineMode } from '@/components/vignettes/shared/useRedlineMode';
+import RedlineOverlay from '@/components/vignettes/shared/RedlineOverlay';
+
+// In AIHighlightsContent:
+const redlineMode = useRedlineMode();
+
+// Map focusedAnnotation to anchor name for HighlightsPanel
+const focusedAnchor = redlineMode.focusedAnnotation
+  ? redlineNotes.find(n => n.id === redlineMode.focusedAnnotation)?.anchor ?? null
+  : null;
+
+// Update panel wrapper with transform on redline mode:
+<motion.div
+  className="relative"
+  style={{ overflow: 'visible' }}
+  animate={{
+    scale: redlineMode.isActive ? 0.98 : 1,
+  }}
+  transition={{ duration: 0.4, ease: 'easeOut' }}
+>
+  <HighlightsPanel
+    stage={stage}
+    onTransition={goToSolution}
+    problemCards={aiHighlightsContent.problemCards}
+    redlineModeActive={redlineMode.isActive}
+    focusedAnchor={focusedAnchor}
+  />
+  <RedlineOverlay
+    isActive={redlineMode.isActive && stage === 'solution'}
+    notes={redlineNotes}
+    accent={accent}
+    focusedAnnotation={redlineMode.focusedAnnotation}
+    onFocusAnnotation={redlineMode.setFocusedAnnotation}
+  />
+</motion.div>
+
+// Update toggle button:
+<button onClick={redlineMode.toggleRedlineMode}>
+  {redlineMode.isActive ? 'Hide design details' : 'Show design details'}
+</button>
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] TypeScript compiles: `npm run build`
+- [x] No lint errors: `npm run lint`
+- [x] Dev server runs: `npm run dev`
+
+#### Manual Verification:
+- [x] Click "Show design details" → panel scales down slightly
+- [x] ~~Dim overlay appears over panel~~ (removed per user feedback)
+- [x] 4 annotations animate in sequentially (staggered ~100ms)
+- [x] Hover annotation → it scales up, others dim
+- [x] Hover off → all return to equal prominence
+- [x] Click toggle again → smooth exit, panel returns to normal
+- [x] Animation runs at 60fps (no jank)
+
+**Implementation Note**: This is the critical phase. If animations aren't smooth here, simplify before proceeding. Pause for manual confirmation.
+
+---
+
+## Phase 2: Polish Desktop Animations
+
+### Overview
+Refine the choreography - connector line draws, dot pulses with spring physics, smoother transitions.
+
+### Changes Required:
+
+#### 1. Add animation presets
+**File**: `src/lib/redline-animations.ts`
+
+```typescript
+export const redlineAnimations = {
+  overlay: {
+    initial: { opacity: 0 },
+    animate: { opacity: 1 },
+    exit: { opacity: 0 },
+    transition: { duration: 0.4 },
+  },
+
+  panelTransform: {
+    active: { scale: 0.98 },
+    inactive: { scale: 1 },
+    transition: { duration: 0.4, ease: 'easeOut' },
+  },
+
+  annotation: (index: number, position: 'left' | 'right') => ({
+    container: {
+      initial: { opacity: 0, x: position === 'right' ? -20 : 20 },
+      animate: { opacity: 1, x: 0 },
+      exit: { opacity: 0, x: position === 'right' ? -20 : 20 },
+      transition: { duration: 0.3, delay: index * 0.1, ease: 'easeOut' },
+    },
+    connector: {
+      initial: { scaleX: 0 },
+      animate: { scaleX: 1 },
+      transition: { duration: 0.15, delay: index * 0.1 },
+    },
+    dot: {
+      initial: { scale: 0 },
+      animate: { scale: [0, 1.3, 1] },
+      transition: {
+        duration: 0.4,
+        delay: index * 0.1 + 0.15,
+        ease: [0.34, 1.56, 0.64, 1],
+      },
+    },
+  }),
+};
+
+// Reduced motion variants
+export const redlineAnimationsReduced = {
+  overlay: {
+    initial: { opacity: 0 },
+    animate: { opacity: 1 },
+    exit: { opacity: 0 },
+    transition: { duration: 0.1 },
+  },
+  panelTransform: {
+    active: { scale: 1 },
+    inactive: { scale: 1 },
+    transition: { duration: 0 },
+  },
+  annotation: () => ({
+    container: {
+      initial: { opacity: 0 },
+      animate: { opacity: 1 },
+      exit: { opacity: 0 },
+      transition: { duration: 0.1 },
+    },
+    connector: {
+      initial: { scaleX: 1 },
+      animate: { scaleX: 1 },
+      transition: { duration: 0 },
+    },
+    dot: {
+      initial: { scale: 1 },
+      animate: { scale: 1 },
+      transition: { duration: 0 },
+    },
+  }),
+};
+```
+
+#### 2. Add reduced motion hook
+**File**: `src/lib/useReducedMotion.ts`
+
+```typescript
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export function useReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const query = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setPrefersReducedMotion(query.matches);
+
+    const handler = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    query.addEventListener('change', handler);
+    return () => query.removeEventListener('change', handler);
+  }, []);
+
+  return prefersReducedMotion;
+}
+```
+
+#### 3. Update RedlineOverlay to use animation presets
+**File**: `src/components/vignettes/shared/RedlineOverlay.tsx`
+**Changes**: Import and apply animation presets, respect reduced motion
+
+```tsx
+import { useReducedMotion } from '@/lib/useReducedMotion';
+import { redlineAnimations, redlineAnimationsReduced } from '@/lib/redline-animations';
+
+// In component:
+const reducedMotion = useReducedMotion();
+const animations = reducedMotion ? redlineAnimationsReduced : redlineAnimations;
+
+// Apply animations from presets instead of inline
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] TypeScript compiles: `npm run build`
+- [x] No lint errors: `npm run lint`
+
+#### Manual Verification:
+- [x] Connector lines draw outward from anchor
+- [x] Dots pop in with spring/bounce effect
+- [x] Label boxes slide in smoothly
+- [x] Stagger timing feels natural (not robotic)
+- [x] Enable "Reduce motion" in OS settings → animations become instant fades
+- [x] Performance still 60fps
+
+**Implementation Note**: Pause for manual confirmation before mobile phase.
+
+---
+
+## Phase 3: Mobile Bottom Sheet Tour
+
+### Overview
+Build the mobile experience - a swipeable bottom sheet that shows one annotation at a time with progress indicators.
+
+### Changes Required:
+
+#### 1. Create MobileRedlineTour component
+**File**: `src/components/vignettes/shared/MobileRedlineTour.tsx`
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { motion, AnimatePresence, PanInfo } from 'framer-motion';
+import type { DesignNote } from '@/components/vignettes/types';
+
+interface MobileRedlineTourProps {
+  isActive: boolean;
+  notes: DesignNote[];
+  accent: string;
+  onExit: () => void;
+}
+
+export default function MobileRedlineTour({
+  isActive,
+  notes,
+  accent,
+  onExit,
+}: MobileRedlineTourProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const handleDragEnd = (_: unknown, info: PanInfo) => {
+    const threshold = 50;
+    if (info.offset.x < -threshold && currentIndex < notes.length - 1) {
+      setCurrentIndex(prev => prev + 1);
+    } else if (info.offset.x > threshold && currentIndex > 0) {
+      setCurrentIndex(prev => prev - 1);
+    } else if (info.offset.y > threshold) {
+      onExit();
+    }
+  };
+
+  const currentNote = notes[currentIndex];
+
+  return (
+    <AnimatePresence>
+      {isActive && (
+        <>
+          {/* Backdrop */}
+          <motion.div
+            className="fixed inset-0 bg-black/40 z-40 lg:hidden"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onExit}
+          />
+
+          {/* Bottom Sheet */}
+          <motion.div
+            className="fixed inset-x-0 bottom-0 bg-white rounded-t-2xl z-50 lg:hidden"
+            initial={{ y: '100%' }}
+            animate={{ y: 0 }}
+            exit={{ y: '100%' }}
+            transition={{ type: 'spring', damping: 25, stiffness: 300 }}
+            drag="y"
+            dragConstraints={{ top: 0, bottom: 0 }}
+            dragElastic={{ top: 0, bottom: 0.5 }}
+            onDragEnd={handleDragEnd}
+          >
+            {/* Handle */}
+            <div className="flex justify-center pt-3 pb-2">
+              <div className="w-10 h-1 bg-gray-300 rounded-full" />
+            </div>
+
+            {/* Progress */}
+            <div className="px-6 pb-2 flex items-center justify-between">
+              <span className="text-sm text-gray-500">
+                {currentIndex + 1} of {notes.length}
+              </span>
+              <div className="flex gap-1.5">
+                {notes.map((_, i) => (
+                  <button
+                    key={i}
+                    className={`w-2 h-2 rounded-full transition-colors ${
+                      i === currentIndex ? 'bg-gray-900' : 'bg-gray-300'
+                    }`}
+                    onClick={() => setCurrentIndex(i)}
+                    aria-label={`Go to annotation ${i + 1}`}
+                  />
+                ))}
+              </div>
+            </div>
+
+            {/* Content */}
+            <div className="px-6 pb-8 min-h-[180px]">
+              <AnimatePresence mode="wait">
+                <motion.div
+                  key={currentNote.id}
+                  initial={{ opacity: 0, x: 20 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: -20 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  <h3
+                    className="text-lg font-semibold mb-2"
+                    style={{ color: accent }}
+                  >
+                    {currentNote.label}
+                  </h3>
+                  <p className="text-gray-600 leading-relaxed">
+                    {currentNote.detail}
+                  </p>
+                </motion.div>
+              </AnimatePresence>
+            </div>
+
+            {/* Navigation */}
+            <div className="px-6 pb-6 flex gap-3">
+              <button
+                className="flex-1 py-3 px-4 rounded-xl border border-gray-200 text-gray-700 font-medium disabled:opacity-40"
+                onClick={() => setCurrentIndex(prev => prev - 1)}
+                disabled={currentIndex === 0}
+              >
+                Previous
+              </button>
+              <button
+                className="flex-1 py-3 px-4 rounded-xl font-medium text-white"
+                style={{ backgroundColor: accent }}
+                onClick={() => {
+                  if (currentIndex === notes.length - 1) {
+                    onExit();
+                  } else {
+                    setCurrentIndex(prev => prev + 1);
+                  }
+                }}
+              >
+                {currentIndex === notes.length - 1 ? 'Done' : 'Next'}
+              </button>
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}
+```
+
+#### 2. Add mobile markers on panel
+**File**: `src/components/vignettes/shared/MobileRedlineMarkers.tsx`
+
+```tsx
+'use client';
+
+import { motion } from 'framer-motion';
+import type { DesignNote } from '@/components/vignettes/types';
+
+interface MobileRedlineMarkersProps {
+  notes: DesignNote[];
+  accent: string;
+  currentIndex: number;
+  onMarkerClick: (index: number) => void;
+}
+
+export default function MobileRedlineMarkers({
+  notes,
+  accent,
+  currentIndex,
+  onMarkerClick,
+}: MobileRedlineMarkersProps) {
+  return (
+    <div className="lg:hidden pointer-events-auto" style={{ overflow: 'visible' }}>
+      {notes.map((note, index) => (
+        <motion.button
+          key={note.id}
+          className="design-note-marker"
+          data-position={note.position}
+          style={{
+            positionAnchor: `--${note.anchor}`,
+            '--accent': accent,
+          } as React.CSSProperties}
+          animate={{
+            scale: currentIndex === index ? 1.2 : 1,
+            boxShadow: currentIndex === index
+              ? `0 0 0 8px ${accent}40`
+              : `0 0 0 4px ${accent}1a`,
+          }}
+          transition={{ duration: 0.2 }}
+          onClick={() => onMarkerClick(index)}
+          aria-label={`Design note ${index + 1}: ${note.label}`}
+        >
+          {index + 1}
+        </motion.button>
+      ))}
+    </div>
+  );
+}
+```
+
+#### 3. Add mobile marker CSS
+**File**: `src/components/vignettes/shared/design-notes.css`
+**Changes**: Add marker styles
+
+```css
+/* Mobile Design Note Markers */
+.design-note-marker {
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--accent, #ef4444);
+  color: white;
+  font-size: 12px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 10;
+  border: 2px solid white;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+/* Expand tap target */
+.design-note-marker::before {
+  content: '';
+  position: absolute;
+  inset: -10px;
+}
+
+.design-note-marker[data-position="right"] {
+  left: anchor(right);
+  top: anchor(center);
+  translate: 8px -50%;
+}
+
+.design-note-marker[data-position="left"] {
+  right: anchor(left);
+  top: anchor(center);
+  translate: -8px -50%;
+}
+
+@media (min-width: 1024px) {
+  .design-note-marker {
+    display: none;
+  }
+}
+
+@supports not (anchor-name: --test) {
+  .design-note-marker {
+    display: none; /* Hide on unsupported browsers for mobile */
+  }
+}
+```
+
+#### 4. Integrate mobile components into AIHighlightsVignette
+**File**: `src/components/vignettes/ai-highlights/AIHighlightsVignette.tsx`
+**Changes**: Add mobile tour and markers, manage currentIndex state
+
+```tsx
+import MobileRedlineTour from '@/components/vignettes/shared/MobileRedlineTour';
+import MobileRedlineMarkers from '@/components/vignettes/shared/MobileRedlineMarkers';
+
+// Add to useRedlineMode or local state:
+const [mobileIndex, setMobileIndex] = useState(0);
+
+// Reset index when exiting
+const handleExit = () => {
+  redlineMode.exitRedlineMode();
+  setMobileIndex(0);
+};
+
+// In render, after HighlightsPanel:
+{redlineMode.isActive && stage === 'solution' && (
+  <MobileRedlineMarkers
+    notes={redlineNotes}
+    accent={accent}
+    currentIndex={mobileIndex}
+    onMarkerClick={setMobileIndex}
+  />
+)}
+
+// At component root level (outside VignetteSplit):
+<MobileRedlineTour
+  isActive={redlineMode.isActive && stage === 'solution'}
+  notes={redlineNotes}
+  accent={accent}
+  onExit={handleExit}
+/>
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] TypeScript compiles: `npm run build`
+- [x] No lint errors: `npm run lint`
+
+#### Manual Verification:
+- [ ] On mobile viewport (<1024px), toggle shows bottom sheet
+- [ ] Swipe left → next annotation
+- [ ] Swipe right → previous annotation
+- [ ] Swipe down → exits redline mode
+- [ ] Tap progress dots → jumps to that annotation
+- [ ] Tap marker on panel → jumps to that annotation in sheet
+- [ ] Current marker pulses/highlights
+- [ ] "Done" button on last annotation exits mode
+- [ ] Desktop view unchanged
+
+**Implementation Note**: Pause for manual confirmation before accessibility phase.
+
+---
+
+## Phase 4: Accessibility & Keyboard Navigation
+
+### Overview
+Add keyboard navigation, focus management, screen reader support, and ensure reduced motion works everywhere.
+
+### Changes Required:
+
+#### 1. Add keyboard navigation to RedlineOverlay
+**File**: `src/components/vignettes/shared/RedlineOverlay.tsx`
+**Changes**: Add keyboard event handling, focus management
+
+```tsx
+import { useEffect, useRef } from 'react';
+
+// Add ref for focus management
+const containerRef = useRef<HTMLDivElement>(null);
+
+// Focus trap and keyboard handling
+useEffect(() => {
+  if (!isActive) return;
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    switch (e.key) {
+      case 'Escape':
+        onExit?.();
+        break;
+      case 'Tab':
+        // Cycle through annotations
+        e.preventDefault();
+        const currentIdx = notes.findIndex(n => n.id === focusedAnnotation);
+        const nextIdx = e.shiftKey
+          ? (currentIdx - 1 + notes.length) % notes.length
+          : (currentIdx + 1) % notes.length;
+        onFocusAnnotation(notes[nextIdx].id);
+        break;
+    }
+  };
+
+  document.addEventListener('keydown', handleKeyDown);
+  return () => document.removeEventListener('keydown', handleKeyDown);
+}, [isActive, focusedAnnotation, notes, onFocusAnnotation]);
+
+// Add to annotation elements:
+tabIndex={0}
+role="button"
+aria-label={`Design note: ${note.label}. ${note.detail}`}
+onFocus={() => onFocusAnnotation(note.id)}
+onBlur={() => onFocusAnnotation(null)}
+```
+
+#### 2. Add screen reader announcements
+**File**: `src/components/vignettes/shared/RedlineOverlay.tsx`
+**Changes**: Add live region for mode changes
+
+```tsx
+// Add at component level:
+<div
+  role="status"
+  aria-live="polite"
+  className="sr-only"
+>
+  {isActive
+    ? `Design annotation mode activated. Showing ${notes.length} design notes. Use Tab to navigate between annotations, Escape to exit.`
+    : ''
+  }
+</div>
+```
+
+#### 3. Add keyboard navigation to MobileRedlineTour
+**File**: `src/components/vignettes/shared/MobileRedlineTour.tsx`
+**Changes**: Arrow key navigation
+
+```tsx
+useEffect(() => {
+  if (!isActive) return;
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    switch (e.key) {
+      case 'Escape':
+        onExit();
+        break;
+      case 'ArrowRight':
+      case 'ArrowDown':
+        if (currentIndex < notes.length - 1) {
+          setCurrentIndex(prev => prev + 1);
+        }
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        if (currentIndex > 0) {
+          setCurrentIndex(prev => prev - 1);
+        }
+        break;
+      case 'Home':
+        setCurrentIndex(0);
+        break;
+      case 'End':
+        setCurrentIndex(notes.length - 1);
+        break;
+    }
+  };
+
+  document.addEventListener('keydown', handleKeyDown);
+  return () => document.removeEventListener('keydown', handleKeyDown);
+}, [isActive, currentIndex, notes.length, onExit]);
+```
+
+#### 4. Ensure all animations respect reduced motion
+Review all components and ensure they import and use `useReducedMotion` hook.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] TypeScript compiles: `npm run build`
+- [ ] No lint errors: `npm run lint`
+
+#### Manual Verification:
+- [ ] Tab cycles through annotations on desktop
+- [ ] Escape exits redline mode
+- [ ] Arrow keys navigate on mobile tour
+- [ ] Screen reader announces mode activation
+- [ ] Screen reader reads annotation content on focus
+- [ ] Reduced motion: all animations become instant fades
+- [ ] Focus rings visible on all interactive elements
+
+**Implementation Note**: This completes the implementation.
+
+---
+
+## Testing Strategy
+
+### Manual Testing Steps:
+1. Desktop Chrome: Full flow (toggle, hover each annotation, exit)
+2. Desktop Firefox: Same flow (check anchor positioning fallback if needed)
+3. Desktop Safari: Same flow
+4. Mobile Chrome (DevTools): Toggle, swipe through all, exit via swipe down
+5. Mobile Safari (real device if possible): Same flow
+6. Keyboard only: Navigate entire feature without mouse
+7. Screen reader (VoiceOver/NVDA): Verify announcements
+8. Reduced motion enabled: Verify instant transitions
+
+### Edge Cases:
+- Rapidly toggling redline mode on/off
+- Resizing viewport while mode is active
+- Switching between problem/solution stages while mode is active
+- Browser back button while mode is active
+
+## Performance Considerations
+
+- All animations use `transform` and `opacity` only (GPU-accelerated)
+- No layout thrashing (no reads then writes in animation frames)
+- Intersection Observer for any scroll-linked effects (not scroll events)
+- Bottom sheet uses spring physics (no manual frame calculations)
+
+## Kill Switch
+
+If Phase 1 animations aren't smooth:
+1. Remove the scale transform on the panel
+2. Remove the dim overlay
+3. Keep just the annotation reveal with simple fade-in
+4. This gives you "annotations on toggle" without transformation risk
+
+## References
+
+- Research: `thoughts/shared/research/2025-12-16-mobile-annotation-patterns.md`
+- Concept B exploration: Zoom/transform "Redline Mode" detailed choreography
+- Existing implementation: `src/components/vignettes/ai-highlights/AIHighlightsVignette.tsx`

--- a/thoughts/shared/research/2025-12-16-mobile-annotation-patterns.md
+++ b/thoughts/shared/research/2025-12-16-mobile-annotation-patterns.md
@@ -1,331 +1,222 @@
 ---
-date: 2025-12-16T22:16:35+11:00
-git_commit: 1c22f6589d853faff2959a43fc62826c247f33d6
+date: 2025-12-16T22:55:11+11:00
+git_commit: 361297b82e4bf24bcd7aeeae31b8704cfcd89eb7
 branch: refine-notes
 repository: idamadam.com
-topic: "Mobile Annotation UX Patterns for Design Portfolio"
-tags: [research, ux-patterns, mobile, annotations, design-notes, portfolio]
+topic: "How to adapt desktop redline annotations for mobile screens while maintaining the interactive case study feel"
+tags: [research, ux-patterns, ai-highlights, design-notes, responsive, mobile]
 status: complete
 last_updated: 2025-12-16
 last_updated_by: claude
 ---
 
-# Research: Mobile Annotation UX Patterns for Design Portfolio
-
-**Date**: 2025-12-16T22:16:35+11:00
-**Git Commit**: 1c22f6589d853faff2959a43fc62826c247f33d6
-**Branch**: refine-notes
-**Repository**: idamadam.com
-
-## Research Question
-
-How can design annotations (redlines) be displayed effectively on mobile devices while maintaining the "designer markup" aesthetic? The current implementation uses CSS anchor positioning which works well on desktop but positions notes off-screen on mobile.
-
-## Context
-
-The AI Highlights vignette (`src/components/vignettes/ai-highlights/`) features design annotations that appear alongside UI elements when "Show design details" is toggled. These notes use CSS anchor positioning to attach to specific elements (header, highlight item, opportunity item, feedback footer) with left/right positioning.
-
-On mobile, the VignetteSplit layout stacks vertically and the panel takes full width, causing notes positioned to the left/right to extend beyond the viewport.
-
-## Summary
-
-Six primary patterns emerged from research that could solve mobile annotation display while preserving the "designer redline" aesthetic:
-
-1. **Pulsing Hotspots + Tap-to-Reveal** - Numbered dots that reveal tooltips on tap
-2. **Sticky Bottom Sheet** - Persistent annotation panel at screen bottom
-3. **Scroll-Triggered Sequential Reveal** - Notes fade in as sections enter viewport
-4. **X-Ray / Layered Toggle** - Semi-transparent overlay with dimmed background
-5. **Swipeable Card Stack** - Horizontal carousel of annotation cards
-6. **Inline Expansion** - Accordion-style notes that expand within the panel
-
-## Detailed Findings
-
-### Pattern 1: Pulsing Hotspots + Tap-to-Reveal
-
-Small numbered or colored dots placed on UI elements that pulse gently to draw attention. Tapping reveals the annotation in a tooltip or popover near the dot.
-
-**Key characteristics:**
-- Multiple hotspots can be visible simultaneously
-- Only one expands at a time
-- Users explore at their own pace
-- Handwritten/sketch-style fonts signal these are annotations, not UI
-
-**UX considerations:**
-- Hotspots should use subtle animation (not aggressive pulsing)
-- Color and intensity should create calm, non-intrusive experience
-- Build with two parts: explanation block + dismiss action
-- User should always have ability to skip/close
-
-**Sources:**
-- [Appcues - Tooltips & Hotspots](https://docs.appcues.com/flows/tooltips-hotspots)
-- [Smashing Magazine - Designing Tooltips for Mobile](https://www.smashingmagazine.com/2021/02/designing-tooltips-mobile-user-interfaces/)
-- [UserGuiding - Hotspot Examples](https://userguiding.com/blog/hotspot-ux)
-- [FlowMapp - What Are Coach Marks](https://www.flowmapp.com/blog/qa/coach-marks)
-
-**Implementation complexity:** Medium
-**Fidelity to desktop experience:** High
-
----
-
-### Pattern 2: Sticky Bottom Sheet
-
-A non-modal bottom sheet that stays visible at the bottom of the screen, showing the current annotation. Users can swipe through notes or scroll the main panel to auto-update which note is shown.
-
-**Key characteristics:**
-- Provides more space than traditional dialogs
-- Snaps to three out of four edges of screen
-- Can be expanded/collapsed but not fully dismissed
-- Supports scrolling content within the sheet
-
-**UX considerations:**
-- Keep tasks short and simple
-- Don't navigate between views within bottom sheets
-- Support Back gesture for dismissal
-- Use sticky action bars for clear next steps
-- Top bar should elevate and remain sticky when scrolling
-
-**Real-world examples:**
-- Google Maps location details
-- Apple Maps place cards
-- Uber ride selection
-
-**Sources:**
-- [NN/g - Bottom Sheets Definition and Guidelines](https://www.nngroup.com/articles/bottom-sheet/)
-- [Material Design 3 - Bottom Sheets](https://m3.material.io/components/bottom-sheets/guidelines)
-- [LogRocket - Bottom Sheets for Optimized UX](https://blog.logrocket.com/ux-design/bottom-sheets-optimized-ux/)
-- [Mobbin - Bottom Sheet Examples](https://mobbin.com/explore/mobile/ui-elements/bottom-sheet)
-
-**Implementation complexity:** Low
-**Fidelity to desktop experience:** Medium
-
----
-
-### Pattern 3: Scroll-Triggered Sequential Reveal
-
-As users scroll through the panel, annotations fade in when their associated section enters the viewport. The note appears directly above or below its anchor, with a short connector line.
-
-**Key characteristics:**
-- Animation tied to scroll position
-- Progressive reveal creates narrative flow
-- Notes communicate spatial relationships
-- Can use parallax-like effects (sparingly)
-
-**UX considerations:**
-- Reduce animation duration on mobile to avoid lag
-- Set up element-specific scroll triggers
-- Replace hover animations with tap animations on mobile
-- Don't hijack scroll - enhance, don't overwhelm
-- Keep annotations brief and scannable
-
-**Real-world examples:**
-- Apple product pages
-- Stripe feature explanations
-- Rally Interactive
-
-**Sources:**
-- [Zach Sean - Complete Guide to Scroll-Based Interactions](https://www.zachsean.com/post/the-complete-guide-to-scroll-based-interactions-in-modern-web-design)
-- [Number Analytics - Scroll-Triggered Animations in Design](https://www.numberanalytics.com/blog/scroll-triggered-animations-design)
-- [UI Deploy - Complete Scrollytelling Guide 2025](https://ui-deploy.com/blog/complete-scrollytelling-guide-how-to-create-interactive-web-narratives-2025)
-- [Qode Interactive - Scroll-triggered Animation Examples](https://qodeinteractive.com/magazine/scroll-triggered-animations/)
-
-**Implementation complexity:** Medium
-**Fidelity to desktop experience:** High (maintains spatial relationship)
-
----
-
-### Pattern 4: X-Ray / Layered Toggle
-
-When "Show design details" is active, a semi-transparent annotation layer appears over the panel. Notes are positioned with arrows pointing to their targets. The underlying UI dims slightly to create visual separation.
-
-**Key characteristics:**
-- Creates "seeing through" metaphor
-- Skillful play with masking reveals background
-- Can apply to various elements beyond just content
-- Coach marks use this pattern with dimmed backgrounds
-
-**UX considerations:**
-- Use different font for annotations vs main UI
-- Handwritten/sketch fonts signal these are notes
-- Always provide opportunity to dismiss
-- Don't cover essential content users need to see
-
-**Real-world examples:**
-- Figma Dev Mode annotations
-- Zeplin design specs
-- App onboarding coach marks (Slack, Google Plus)
-
-**Sources:**
-- [Speckyboy - X-Ray Effects in Web Design](https://speckyboy.com/looking-through-the-use-of-x-ray-effects/)
-- [Creative Bloq - Walkthroughs and Coach Marks](https://www.creativebloq.com/ux/ui-design-pattern-tips-walkthroughs-and-coach-marks-101413265)
-- [UI Patterns - Coachmarks](https://ui-patterns.com/patterns/coachmarks)
-- [NN/g - Instructional Overlays for Mobile Apps](https://www.nngroup.com/articles/mobile-instructional-overlay/)
-
-**Implementation complexity:** Medium-High
-**Fidelity to desktop experience:** Highest
-
----
-
-### Pattern 5: Swipeable Card Stack
-
-Annotations become a horizontal carousel of cards at the bottom (or top). Swiping through cards highlights the corresponding element in the panel above. Small numbered indicators on the UI show which card relates to which element.
-
-**Key characteristics:**
-- Card-based UI is highly adaptive to screen sizes
-- Rectangular shape makes cards transformative across devices
-- Discovery mechanism creates engagement
-- Each swipe gathers information
-
-**UX considerations:**
-- Display only most useful information, reveal more on interaction
-- Mobile users expect to swipe through carousels
-- Can create narrative that captures attention
-- Works well for storytelling or presenting series of related items
-
-**Real-world examples:**
-- Tinder card swiping
-- Instagram Stories
-- TikTok content discovery
-- App Store feature cards
-
-**Sources:**
-- [Smashing Magazine - Designing Card-Based UIs](https://www.smashingmagazine.com/2016/10/designing-card-based-user-interfaces/)
-- [Eleken - Card UI Examples](https://www.eleken.co/blog-posts/card-ui-examples-and-best-practices-for-product-owners)
-- [Justinmind - Carousel Best Practices](https://www.justinmind.com/ui-design/carousel)
-- [Medium - Tinder Card Swipe Prototyping](https://medium.com/@FullStackDesigner/tinder-card-swipe-figma-prototyping-9c9e78fff869)
-
-**Implementation complexity:** Medium
-**Fidelity to desktop experience:** Medium
-
----
-
-### Pattern 6: Inline Expansion (Accordion Style)
-
-When notes are active, each annotated section gets a subtle accent border and a small "note" indicator. Tapping the indicator expands the note inline, pushing content down temporarily.
-
-**Key characteristics:**
-- Annotation appears right where it's relevant
-- No navigation away from context
-- Similar to Hypothesis web annotations on mobile
-- Comment layer can appear at bottom, swipe through horizontally
-
-**UX considerations:**
-- Being a native pattern solves traditional UX headaches
-- Can view comments and content at once
-- Avoid having annotation drawer interfere with site UX
-- Clean implementation doesn't show anything until interaction
-
-**Real-world examples:**
-- Hypothesis annotation on mobile
-- Medium's inline highlights
-- Kindle book annotations
-
-**Sources:**
-- [Tom Critchlow - Exploring the UX of Web Annotations](https://tomcritchlow.com/2019/02/12/annotations/)
-- [Hypothesis - Annotation Basics](https://web.hypothes.is/help/annotation-basics/)
-- [Appcues - Tooltips for Mobile Apps](https://www.appcues.com/blog/tooltips-mobile-apps)
-
-**Implementation complexity:** Low
-**Fidelity to desktop experience:** Medium
-
----
-
-## Additional Patterns Considered
-
-### Before/After Comparison Slider
-A draggable slider that reveals annotations underneath the design. While visually interesting, this pattern is better suited for comparing two static images rather than displaying multiple contextual annotations.
-
-**Source:** [Figma - Screen Comparison Slider](https://www.figma.com/community/file/1195702107552745271/screen-comparison-slider-mobile-before-after)
-
-### Apple Popovers
-iOS popovers point directly to source elements but are designed for larger screens (iPad). On iPhone, they typically convert to full-screen sheets, losing spatial connection.
-
-**Source:** [Apple HIG - Popovers](https://developer.apple.com/design/human-interface-guidelines/popovers)
-
-### Instagram Story Stickers
-Overlay stickers can present supplemental information without cluttering the main visual, but lack the precision pointing/connector aesthetic of design annotations.
-
-**Source:** [FilterGrade - Instagram Story Overlays](https://filtergrade.com/how-to-use-overlays-and-stickers-on-instagram-stories/)
-
----
-
-## Comparison Matrix
-
-| Pattern | Spatial Connection | Implementation | Interactivity | Designer Feel |
-|---------|-------------------|----------------|---------------|---------------|
-| Pulsing Hotspots | High | Medium | High | High |
-| Bottom Sheet | Low | Low | Medium | Medium |
-| Scroll-Triggered | High | Medium | Low | High |
-| X-Ray Layer | Highest | Medium-High | Low | Highest |
-| Swipeable Cards | Medium | Medium | High | Medium |
-| Inline Expansion | Medium | Low | Medium | Medium |
-
----
-
-## Recommendations
-
-### For maximum "designer redline" authenticity:
-**X-Ray Layer** or **Pulsing Hotspots**
-
-These patterns best preserve the feeling of looking at a designer's marked-up work. The X-ray approach maintains the layered annotation aesthetic, while hotspots allow precise spatial pointing with reveal interactions.
-
-### For simplest implementation:
-**Bottom Sheet** or **Inline Expansion**
-
-Both leverage well-established mobile patterns with straightforward implementation. Bottom sheet is particularly well-documented in Material Design and iOS.
-
-### For most engaging/novel experience:
-**Swipeable Cards** or **Scroll-Triggered**
-
-Swipeable cards tap into familiar mobile gestures (Instagram, TikTok) while scroll-triggered creates a guided narrative experience.
-
-### Hybrid approach to consider:
-Combine **Pulsing Hotspots** (for spatial indication) with **Bottom Sheet** (for annotation content). Tapping a hotspot updates the bottom sheet content and highlights the connection.
-
----
-
-## Technical Considerations for Implementation
-
-### CSS/React considerations:
-- Use `@media` queries to switch between desktop anchor positioning and mobile alternative
-- Framer Motion's `AnimatePresence` already in use - can leverage for transitions
-- Consider `react-intersection-observer` (already in project) for scroll-triggered reveals
-- Bottom sheets can use CSS `position: fixed` with transform animations
-
-### Accessibility:
-- Ensure tap targets are minimum 44x44px on mobile
-- Provide way to dismiss all annotations
-- Consider reduced-motion preferences for animations
-- Maintain focus management for keyboard/screen reader users
-
-### Performance:
-- Lazy-load annotation content if using cards/sheets
-- Debounce scroll events if using scroll-triggered pattern
-- Prefer CSS animations over JS where possible
-
----
-
-## Open Questions
-
-1. Should mobile annotations be opt-in (hidden by default) or automatically adapted from desktop?
-2. Is maintaining the red accent color/connector line aesthetic important, or can mobile take a different visual approach?
-3. Should annotations be viewable alongside the panel, or is a dedicated "annotation mode" acceptable?
-4. How important is seeing all annotations at once vs. exploring one at a time?
-
----
-
-## Related Resources
-
-### Design Pattern Libraries
-- [Mobbin - Mobile UI Patterns](https://mobbin.com/)
-- [UI Patterns](https://ui-patterns.com/)
-- [Page Flows](https://pageflows.com/)
-
-### Portfolio Annotation Examples
-- [Learn UI Design - Portfolio Examples](https://www.learnui.design/blog/great-design-portfolio-examples.html)
-- [Awwwards - Portfolio Case Studies](https://www.awwwards.com/websites/portfolio/)
-- [Dribbble - Case Study Presentations](https://dribbble.com/tags/case-study)
-
-### Technical Implementation
-- [Figma Dev Mode](https://www.figma.com/dev-mode/)
-- [Material Design Bottom Sheets](https://m3.material.io/components/bottom-sheets/overview)
-- [Apple HIG Components](https://developer.apple.com/design/human-interface-guidelines/components)
+# Research: Mobile Annotation Patterns for Design Redlines
+
+## Recommendation
+
+**Use numbered markers with a stacked annotation list below the panel on mobile.** This preserves the "peek behind the curtains" feel by keeping visual markers on the UI mockup while moving the detailed callout text to a tappable accordion below. The bidirectional tap-to-highlight interaction maintains interactivity without fighting the vertical mobile layout. This approach reuses your existing anchor positioning for marker placement and leverages Framer Motion patterns already in your codebase.
+
+## Quick Comparison
+
+| Option | Effort | A11y | Uses Existing | Risk | Verdict |
+|--------|--------|------|---------------|------|---------|
+| A: Numbered markers + stacked list | 4-6h | ✓ | Anchor positions, Framer ✓ | Low | **Recommended** |
+| B: Bottom sheet overlay | 3-4h | ✓ | New primitive needed | Med | Quick fallback |
+| C: Coach marks (sequential) | 6-8h | ~ | Custom overlay system | High | Skip - feels tutorial-y |
+
+## Constraints Considered
+
+- **Stack**: React 19, Framer Motion, CSS anchor positioning (with fallbacks)
+- **Existing patterns**: `VignetteSplit` stacks vertically on mobile (`lg:grid-cols-[360px_1fr]`), `InlineRedlines` uses CSS anchor() for positioning
+- **Priority**: Maintain "interactive case study" spirit, show design thinking, keep it explorable rather than passive
+
+## Option A: Numbered Markers + Stacked List (Recommended)
+
+### Why this works
+
+Your existing CSS anchor positioning already knows where each annotation should appear on the mockup. On mobile, you keep those coordinates but swap the extended callout boxes for small numbered circles. The detailed text moves below the panel in an accordion-style list. Tapping a number in the list pulses the corresponding marker on the mockup (and vice versa), creating a two-way "show me where" interaction that feels like a designer walking someone through their work.
+
+### Implementation sketch
+
+```tsx
+// MobileDesignNotes.tsx - shown only on mobile
+function MobileDesignNotes({ notes, accent }: { notes: DesignNote[], accent: string }) {
+  const [activeNote, setActiveNote] = useState<string | null>(null);
+
+  return (
+    <>
+      {/* Markers overlaid on the panel - small numbered circles */}
+      <div className="lg:hidden pointer-events-auto">
+        {notes.map((note, i) => (
+          <motion.button
+            key={note.id}
+            className="design-note-marker"
+            data-position={note.position}
+            style={{ positionAnchor: `--${note.anchor}` }}
+            animate={{
+              scale: activeNote === note.id ? 1.3 : 1,
+              boxShadow: activeNote === note.id
+                ? `0 0 0 8px ${accent}40`
+                : `0 0 0 4px ${accent}1a`
+            }}
+            onClick={() => setActiveNote(note.id)}
+          >
+            {i + 1}
+          </motion.button>
+        ))}
+      </div>
+
+      {/* Stacked list below panel */}
+      <div className="lg:hidden mt-6 space-y-2">
+        {notes.map((note, i) => (
+          <motion.button
+            key={note.id}
+            className="w-full text-left p-3 rounded-xl border flex items-start gap-3"
+            style={{
+              borderColor: activeNote === note.id ? accent : '#e5e7eb',
+              backgroundColor: activeNote === note.id ? `${accent}08` : 'white'
+            }}
+            onClick={() => setActiveNote(note.id)}
+          >
+            <span
+              className="w-6 h-6 rounded-full flex items-center justify-center text-xs font-medium text-white shrink-0"
+              style={{ backgroundColor: accent }}
+            >
+              {i + 1}
+            </span>
+            <div>
+              <p className="font-semibold text-sm" style={{ color: accent }}>{note.label}</p>
+              <p className="text-sm text-gray-600 mt-0.5">{note.detail}</p>
+            </div>
+          </motion.button>
+        ))}
+      </div>
+    </>
+  );
+}
+```
+
+```css
+/* design-notes.css additions */
+.design-note-marker {
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: white;
+  font-size: 12px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 10;
+}
+
+/* Reuse existing anchor positioning for markers */
+.design-note-marker[data-position="right"] {
+  left: anchor(right);
+  top: anchor(center);
+  translate: 8px -50%;
+}
+
+.design-note-marker[data-position="left"] {
+  right: anchor(left);
+  top: anchor(center);
+  translate: -8px -50%;
+}
+
+@media (min-width: 1024px) {
+  .design-note-marker { display: none; }
+}
+```
+
+### Effort
+
+4-6 hours to MVP: Create `MobileDesignNotes` component, add CSS for markers, wire up state for highlighting. Add 1-2 hours for polish (smooth scroll to marker, entry animations for list items).
+
+### Gotchas
+
+- **Tap target size**: Markers need to be at least 44px tap target (the visual can be 24px but hit area should be larger via padding)
+- **Anchor positioning fallback**: Your CSS already has `@supports not (anchor-name: --test)` - the markers need fallback percentage positions too
+- **Overlapping markers**: If two anchors are close vertically, markers might overlap - consider slight offset or grouping
+
+## Option B: Bottom Sheet Overlay
+
+### Why this works
+
+Bottom sheets are a native mobile pattern users already understand. Tapping "Show design details" slides up a sheet with all annotations. Each annotation row could highlight its corresponding area on the mockup via a dim overlay with spotlight cutout.
+
+### Implementation sketch
+
+```tsx
+// Uses a modal/sheet pattern
+<AnimatePresence>
+  {showDesignNotes && (
+    <motion.div
+      className="fixed inset-x-0 bottom-0 bg-white rounded-t-2xl shadow-xl z-50 max-h-[60vh] overflow-auto"
+      initial={{ y: '100%' }}
+      animate={{ y: 0 }}
+      exit={{ y: '100%' }}
+    >
+      <div className="sticky top-0 bg-white p-4 border-b flex justify-between items-center">
+        <span className="font-semibold">Design Details</span>
+        <button onClick={toggleDesignNotes}>Close</button>
+      </div>
+      <div className="p-4 space-y-3">
+        {notes.map((note, i) => (
+          <div key={note.id} className="flex gap-3">
+            <NumberBadge>{i + 1}</NumberBadge>
+            <div>
+              <p className="font-semibold">{note.label}</p>
+              <p className="text-sm text-gray-600">{note.detail}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </motion.div>
+  )}
+</AnimatePresence>
+```
+
+### Effort
+
+3-4 hours - simpler than Option A since it doesn't require syncing highlighted states between markers and list.
+
+### Gotchas
+
+- **Disconnection from UI**: The mockup scrolls away or gets obscured when the sheet is open, breaking the visual connection
+- **No spatial context**: Users can't see which annotation refers to which part of the UI without numbered markers on the mockup
+- **Feels more like docs than "peeking behind curtains"**: Less interactive, more reference material
+
+## Option C: Coach Marks (Sequential)
+
+### Why this works
+
+Coach marks dim the entire screen except a spotlighted element, with a callout pointing to it. This is the most "guided tour" approach - users tap through annotations one by one.
+
+### Why I'd skip it
+
+- Feels like onboarding/tutorial, not "exploration"
+- Users can't jump to specific annotations
+- Sequential flow fights against the "glanceable" nature of redlines
+- Requires building a full overlay + spotlight system (6-8h)
+
+## What I Ruled Out
+
+- **Horizontal scroll carousel**: Breaks the "all visible at once" benefit of redlines, feels disconnected
+- **Hover tooltips on markers**: No hover on mobile, tap-and-hold is awkward and undiscoverable
+- **Keeping desktop layout on mobile**: Callout boxes extending left/right would overflow or require horizontal scroll
+- **Hiding annotations entirely on mobile**: Loses the "peek behind the curtains" differentiator
+
+## Sources
+
+- [Mobbin - Bottom Sheet Examples](https://mobbin.com/explore/mobile/ui-elements/bottom-sheet) - Real app patterns for bottom sheets
+- [NN/g - Bottom Sheet Guidelines](https://www.nngroup.com/articles/bottom-sheet/) - When and how to use bottom sheets effectively
+- [NN/g - Mobile Instructional Overlays](https://www.nngroup.com/articles/mobile-instructional-overlay/) - Research on coach marks effectiveness
+- [Smashing Magazine - Mobile Tooltips](https://www.smashingmagazine.com/2021/02/designing-tooltips-mobile-user-interfaces/) - Mobile-specific tooltip considerations
+- [Material Design 3 - Bottom Sheets](https://m3.material.io/components/bottom-sheets) - Platform conventions for sheets
+- [FreeFrontend - CSS Hotspots](https://freefrontend.com/css-hotspots/) - Implementation examples for image markers
+- [Accordion Design Best Practices](https://blog.hubspot.com/website/accordion-design) - When accordion pattern works well
+- [Plotline - Coachmarks and Spotlight](https://www.plotline.so/blog/coachmarks-and-spotlight-ui-mobile-apps) - Mobile coach mark patterns

--- a/thoughts/shared/research/2025-12-16-mobile-annotation-patterns.md
+++ b/thoughts/shared/research/2025-12-16-mobile-annotation-patterns.md
@@ -1,0 +1,331 @@
+---
+date: 2025-12-16T22:16:35+11:00
+git_commit: 1c22f6589d853faff2959a43fc62826c247f33d6
+branch: refine-notes
+repository: idamadam.com
+topic: "Mobile Annotation UX Patterns for Design Portfolio"
+tags: [research, ux-patterns, mobile, annotations, design-notes, portfolio]
+status: complete
+last_updated: 2025-12-16
+last_updated_by: claude
+---
+
+# Research: Mobile Annotation UX Patterns for Design Portfolio
+
+**Date**: 2025-12-16T22:16:35+11:00
+**Git Commit**: 1c22f6589d853faff2959a43fc62826c247f33d6
+**Branch**: refine-notes
+**Repository**: idamadam.com
+
+## Research Question
+
+How can design annotations (redlines) be displayed effectively on mobile devices while maintaining the "designer markup" aesthetic? The current implementation uses CSS anchor positioning which works well on desktop but positions notes off-screen on mobile.
+
+## Context
+
+The AI Highlights vignette (`src/components/vignettes/ai-highlights/`) features design annotations that appear alongside UI elements when "Show design details" is toggled. These notes use CSS anchor positioning to attach to specific elements (header, highlight item, opportunity item, feedback footer) with left/right positioning.
+
+On mobile, the VignetteSplit layout stacks vertically and the panel takes full width, causing notes positioned to the left/right to extend beyond the viewport.
+
+## Summary
+
+Six primary patterns emerged from research that could solve mobile annotation display while preserving the "designer redline" aesthetic:
+
+1. **Pulsing Hotspots + Tap-to-Reveal** - Numbered dots that reveal tooltips on tap
+2. **Sticky Bottom Sheet** - Persistent annotation panel at screen bottom
+3. **Scroll-Triggered Sequential Reveal** - Notes fade in as sections enter viewport
+4. **X-Ray / Layered Toggle** - Semi-transparent overlay with dimmed background
+5. **Swipeable Card Stack** - Horizontal carousel of annotation cards
+6. **Inline Expansion** - Accordion-style notes that expand within the panel
+
+## Detailed Findings
+
+### Pattern 1: Pulsing Hotspots + Tap-to-Reveal
+
+Small numbered or colored dots placed on UI elements that pulse gently to draw attention. Tapping reveals the annotation in a tooltip or popover near the dot.
+
+**Key characteristics:**
+- Multiple hotspots can be visible simultaneously
+- Only one expands at a time
+- Users explore at their own pace
+- Handwritten/sketch-style fonts signal these are annotations, not UI
+
+**UX considerations:**
+- Hotspots should use subtle animation (not aggressive pulsing)
+- Color and intensity should create calm, non-intrusive experience
+- Build with two parts: explanation block + dismiss action
+- User should always have ability to skip/close
+
+**Sources:**
+- [Appcues - Tooltips & Hotspots](https://docs.appcues.com/flows/tooltips-hotspots)
+- [Smashing Magazine - Designing Tooltips for Mobile](https://www.smashingmagazine.com/2021/02/designing-tooltips-mobile-user-interfaces/)
+- [UserGuiding - Hotspot Examples](https://userguiding.com/blog/hotspot-ux)
+- [FlowMapp - What Are Coach Marks](https://www.flowmapp.com/blog/qa/coach-marks)
+
+**Implementation complexity:** Medium
+**Fidelity to desktop experience:** High
+
+---
+
+### Pattern 2: Sticky Bottom Sheet
+
+A non-modal bottom sheet that stays visible at the bottom of the screen, showing the current annotation. Users can swipe through notes or scroll the main panel to auto-update which note is shown.
+
+**Key characteristics:**
+- Provides more space than traditional dialogs
+- Snaps to three out of four edges of screen
+- Can be expanded/collapsed but not fully dismissed
+- Supports scrolling content within the sheet
+
+**UX considerations:**
+- Keep tasks short and simple
+- Don't navigate between views within bottom sheets
+- Support Back gesture for dismissal
+- Use sticky action bars for clear next steps
+- Top bar should elevate and remain sticky when scrolling
+
+**Real-world examples:**
+- Google Maps location details
+- Apple Maps place cards
+- Uber ride selection
+
+**Sources:**
+- [NN/g - Bottom Sheets Definition and Guidelines](https://www.nngroup.com/articles/bottom-sheet/)
+- [Material Design 3 - Bottom Sheets](https://m3.material.io/components/bottom-sheets/guidelines)
+- [LogRocket - Bottom Sheets for Optimized UX](https://blog.logrocket.com/ux-design/bottom-sheets-optimized-ux/)
+- [Mobbin - Bottom Sheet Examples](https://mobbin.com/explore/mobile/ui-elements/bottom-sheet)
+
+**Implementation complexity:** Low
+**Fidelity to desktop experience:** Medium
+
+---
+
+### Pattern 3: Scroll-Triggered Sequential Reveal
+
+As users scroll through the panel, annotations fade in when their associated section enters the viewport. The note appears directly above or below its anchor, with a short connector line.
+
+**Key characteristics:**
+- Animation tied to scroll position
+- Progressive reveal creates narrative flow
+- Notes communicate spatial relationships
+- Can use parallax-like effects (sparingly)
+
+**UX considerations:**
+- Reduce animation duration on mobile to avoid lag
+- Set up element-specific scroll triggers
+- Replace hover animations with tap animations on mobile
+- Don't hijack scroll - enhance, don't overwhelm
+- Keep annotations brief and scannable
+
+**Real-world examples:**
+- Apple product pages
+- Stripe feature explanations
+- Rally Interactive
+
+**Sources:**
+- [Zach Sean - Complete Guide to Scroll-Based Interactions](https://www.zachsean.com/post/the-complete-guide-to-scroll-based-interactions-in-modern-web-design)
+- [Number Analytics - Scroll-Triggered Animations in Design](https://www.numberanalytics.com/blog/scroll-triggered-animations-design)
+- [UI Deploy - Complete Scrollytelling Guide 2025](https://ui-deploy.com/blog/complete-scrollytelling-guide-how-to-create-interactive-web-narratives-2025)
+- [Qode Interactive - Scroll-triggered Animation Examples](https://qodeinteractive.com/magazine/scroll-triggered-animations/)
+
+**Implementation complexity:** Medium
+**Fidelity to desktop experience:** High (maintains spatial relationship)
+
+---
+
+### Pattern 4: X-Ray / Layered Toggle
+
+When "Show design details" is active, a semi-transparent annotation layer appears over the panel. Notes are positioned with arrows pointing to their targets. The underlying UI dims slightly to create visual separation.
+
+**Key characteristics:**
+- Creates "seeing through" metaphor
+- Skillful play with masking reveals background
+- Can apply to various elements beyond just content
+- Coach marks use this pattern with dimmed backgrounds
+
+**UX considerations:**
+- Use different font for annotations vs main UI
+- Handwritten/sketch fonts signal these are notes
+- Always provide opportunity to dismiss
+- Don't cover essential content users need to see
+
+**Real-world examples:**
+- Figma Dev Mode annotations
+- Zeplin design specs
+- App onboarding coach marks (Slack, Google Plus)
+
+**Sources:**
+- [Speckyboy - X-Ray Effects in Web Design](https://speckyboy.com/looking-through-the-use-of-x-ray-effects/)
+- [Creative Bloq - Walkthroughs and Coach Marks](https://www.creativebloq.com/ux/ui-design-pattern-tips-walkthroughs-and-coach-marks-101413265)
+- [UI Patterns - Coachmarks](https://ui-patterns.com/patterns/coachmarks)
+- [NN/g - Instructional Overlays for Mobile Apps](https://www.nngroup.com/articles/mobile-instructional-overlay/)
+
+**Implementation complexity:** Medium-High
+**Fidelity to desktop experience:** Highest
+
+---
+
+### Pattern 5: Swipeable Card Stack
+
+Annotations become a horizontal carousel of cards at the bottom (or top). Swiping through cards highlights the corresponding element in the panel above. Small numbered indicators on the UI show which card relates to which element.
+
+**Key characteristics:**
+- Card-based UI is highly adaptive to screen sizes
+- Rectangular shape makes cards transformative across devices
+- Discovery mechanism creates engagement
+- Each swipe gathers information
+
+**UX considerations:**
+- Display only most useful information, reveal more on interaction
+- Mobile users expect to swipe through carousels
+- Can create narrative that captures attention
+- Works well for storytelling or presenting series of related items
+
+**Real-world examples:**
+- Tinder card swiping
+- Instagram Stories
+- TikTok content discovery
+- App Store feature cards
+
+**Sources:**
+- [Smashing Magazine - Designing Card-Based UIs](https://www.smashingmagazine.com/2016/10/designing-card-based-user-interfaces/)
+- [Eleken - Card UI Examples](https://www.eleken.co/blog-posts/card-ui-examples-and-best-practices-for-product-owners)
+- [Justinmind - Carousel Best Practices](https://www.justinmind.com/ui-design/carousel)
+- [Medium - Tinder Card Swipe Prototyping](https://medium.com/@FullStackDesigner/tinder-card-swipe-figma-prototyping-9c9e78fff869)
+
+**Implementation complexity:** Medium
+**Fidelity to desktop experience:** Medium
+
+---
+
+### Pattern 6: Inline Expansion (Accordion Style)
+
+When notes are active, each annotated section gets a subtle accent border and a small "note" indicator. Tapping the indicator expands the note inline, pushing content down temporarily.
+
+**Key characteristics:**
+- Annotation appears right where it's relevant
+- No navigation away from context
+- Similar to Hypothesis web annotations on mobile
+- Comment layer can appear at bottom, swipe through horizontally
+
+**UX considerations:**
+- Being a native pattern solves traditional UX headaches
+- Can view comments and content at once
+- Avoid having annotation drawer interfere with site UX
+- Clean implementation doesn't show anything until interaction
+
+**Real-world examples:**
+- Hypothesis annotation on mobile
+- Medium's inline highlights
+- Kindle book annotations
+
+**Sources:**
+- [Tom Critchlow - Exploring the UX of Web Annotations](https://tomcritchlow.com/2019/02/12/annotations/)
+- [Hypothesis - Annotation Basics](https://web.hypothes.is/help/annotation-basics/)
+- [Appcues - Tooltips for Mobile Apps](https://www.appcues.com/blog/tooltips-mobile-apps)
+
+**Implementation complexity:** Low
+**Fidelity to desktop experience:** Medium
+
+---
+
+## Additional Patterns Considered
+
+### Before/After Comparison Slider
+A draggable slider that reveals annotations underneath the design. While visually interesting, this pattern is better suited for comparing two static images rather than displaying multiple contextual annotations.
+
+**Source:** [Figma - Screen Comparison Slider](https://www.figma.com/community/file/1195702107552745271/screen-comparison-slider-mobile-before-after)
+
+### Apple Popovers
+iOS popovers point directly to source elements but are designed for larger screens (iPad). On iPhone, they typically convert to full-screen sheets, losing spatial connection.
+
+**Source:** [Apple HIG - Popovers](https://developer.apple.com/design/human-interface-guidelines/popovers)
+
+### Instagram Story Stickers
+Overlay stickers can present supplemental information without cluttering the main visual, but lack the precision pointing/connector aesthetic of design annotations.
+
+**Source:** [FilterGrade - Instagram Story Overlays](https://filtergrade.com/how-to-use-overlays-and-stickers-on-instagram-stories/)
+
+---
+
+## Comparison Matrix
+
+| Pattern | Spatial Connection | Implementation | Interactivity | Designer Feel |
+|---------|-------------------|----------------|---------------|---------------|
+| Pulsing Hotspots | High | Medium | High | High |
+| Bottom Sheet | Low | Low | Medium | Medium |
+| Scroll-Triggered | High | Medium | Low | High |
+| X-Ray Layer | Highest | Medium-High | Low | Highest |
+| Swipeable Cards | Medium | Medium | High | Medium |
+| Inline Expansion | Medium | Low | Medium | Medium |
+
+---
+
+## Recommendations
+
+### For maximum "designer redline" authenticity:
+**X-Ray Layer** or **Pulsing Hotspots**
+
+These patterns best preserve the feeling of looking at a designer's marked-up work. The X-ray approach maintains the layered annotation aesthetic, while hotspots allow precise spatial pointing with reveal interactions.
+
+### For simplest implementation:
+**Bottom Sheet** or **Inline Expansion**
+
+Both leverage well-established mobile patterns with straightforward implementation. Bottom sheet is particularly well-documented in Material Design and iOS.
+
+### For most engaging/novel experience:
+**Swipeable Cards** or **Scroll-Triggered**
+
+Swipeable cards tap into familiar mobile gestures (Instagram, TikTok) while scroll-triggered creates a guided narrative experience.
+
+### Hybrid approach to consider:
+Combine **Pulsing Hotspots** (for spatial indication) with **Bottom Sheet** (for annotation content). Tapping a hotspot updates the bottom sheet content and highlights the connection.
+
+---
+
+## Technical Considerations for Implementation
+
+### CSS/React considerations:
+- Use `@media` queries to switch between desktop anchor positioning and mobile alternative
+- Framer Motion's `AnimatePresence` already in use - can leverage for transitions
+- Consider `react-intersection-observer` (already in project) for scroll-triggered reveals
+- Bottom sheets can use CSS `position: fixed` with transform animations
+
+### Accessibility:
+- Ensure tap targets are minimum 44x44px on mobile
+- Provide way to dismiss all annotations
+- Consider reduced-motion preferences for animations
+- Maintain focus management for keyboard/screen reader users
+
+### Performance:
+- Lazy-load annotation content if using cards/sheets
+- Debounce scroll events if using scroll-triggered pattern
+- Prefer CSS animations over JS where possible
+
+---
+
+## Open Questions
+
+1. Should mobile annotations be opt-in (hidden by default) or automatically adapted from desktop?
+2. Is maintaining the red accent color/connector line aesthetic important, or can mobile take a different visual approach?
+3. Should annotations be viewable alongside the panel, or is a dedicated "annotation mode" acceptable?
+4. How important is seeing all annotations at once vs. exploring one at a time?
+
+---
+
+## Related Resources
+
+### Design Pattern Libraries
+- [Mobbin - Mobile UI Patterns](https://mobbin.com/)
+- [UI Patterns](https://ui-patterns.com/)
+- [Page Flows](https://pageflows.com/)
+
+### Portfolio Annotation Examples
+- [Learn UI Design - Portfolio Examples](https://www.learnui.design/blog/great-design-portfolio-examples.html)
+- [Awwwards - Portfolio Case Studies](https://www.awwwards.com/websites/portfolio/)
+- [Dribbble - Case Study Presentations](https://dribbble.com/tags/case-study)
+
+### Technical Implementation
+- [Figma Dev Mode](https://www.figma.com/dev-mode/)
+- [Material Design Bottom Sheets](https://m3.material.io/components/bottom-sheets/overview)
+- [Apple HIG Components](https://developer.apple.com/design/human-interface-guidelines/components)


### PR DESCRIPTION
## Summary
- Implements "Redline Mode" for design annotations on the AI Highlights vignette
- Desktop: Panel scales down, annotations animate in with stagger, hover effects highlight anchors
- Mobile: Bottom sheet tour with swipe navigation, auto-scrolls panel to show relevant section
- Includes reduced motion support for accessibility

## Test plan
- [ ] Desktop: Click "Show design details" → annotations appear with staggered animation
- [ ] Desktop: Hover annotations → corresponding panel section highlights
- [ ] Mobile (<1024px): Toggle shows bottom sheet with annotation content
- [ ] Mobile: Swipe left/right or tap buttons to navigate between annotations
- [ ] Mobile: Panel scrolls to show the section each annotation refers to
- [ ] Verify reduced motion preference is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)