### PR TITLE
Implement typography system and hero vignette

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,9 @@
     "": {
       "name": "portfolio-nextjs",
       "dependencies": {
+        "@paper-design/shaders-react": "^0.0.68",
         "framer-motion": "^12.23.25",
-        "next": "^16.0.7",
+        "next": "^16.0.10",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-intersection-observer": "^10.0.0",
@@ -121,25 +122,25 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
-    "@next/env": ["@next/env@16.0.7", "", {}, "sha512-gpaNgUh5nftFKRkRQGnVi5dpcYSKGcZZkQffZ172OrG/XkrnS7UBTQ648YY+8ME92cC4IojpI2LqTC8sTDhAaw=="],
+    "@next/env": ["@next/env@16.1.1", "", {}, "sha512-3oxyM97Sr2PqiVyMyrZUtrtM3jqqFxOQJVuKclDsgj/L728iZt/GyslkN4NwarledZATCenbk4Offjk1hQmaAA=="],
 
     "@next/eslint-plugin-next": ["@next/eslint-plugin-next@15.3.3", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-VKZJEiEdpKkfBmcokGjHu0vGDG+8CehGs90tBEy/IDoDDKGngeyIStt2MmE5FYNyU9BhgR7tybNWTAJY/30u+Q=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.0.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LlDtCYOEj/rfSnEn/Idi+j1QKHxY9BJFmxx7108A6D8K0SB+bNgfYQATPk/4LqOl4C0Wo3LACg2ie6s7xqMpJg=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.1.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-JS3m42ifsVSJjSTzh27nW+Igfha3NdBOFScr9C80hHGrWx55pTrVL23RJbqir7k7/15SKlrLHhh/MQzqBBYrQA=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.0.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rtZ7BhnVvO1ICf3QzfW9H3aPz7GhBrnSIMZyr4Qy6boXF0b5E3QLs+cvJmg3PsTCG2M1PBoC+DANUi4wCOKXpA=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.1.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-hbyKtrDGUkgkyQi1m1IyD3q4I/3m9ngr+V93z4oKHrPcmxwNL5iMWORvLSGAf2YujL+6HxgVvZuCYZfLfb4bGw=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.0.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-mloD5WcPIeIeeZqAIP5c2kdaTa6StwP4/2EGy1mUw8HiexSHGK/jcM7lFuS3u3i2zn+xH9+wXJs6njO7VrAqww=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.1.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-/fvHet+EYckFvRLQ0jPHJCUI5/B56+2DpI1xDSvi80r/3Ez+Eaa2Yq4tJcRTaB1kqj/HrYKn8Yplm9bNoMJpwQ=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.0.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-+ksWNrZrthisXuo9gd1XnjHRowCbMtl/YgMpbRvFeDEqEBd523YHPWpBuDjomod88U8Xliw5DHhekBC3EOOd9g=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.1.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.0.7", "", { "os": "linux", "cpu": "x64" }, "sha512-4WtJU5cRDxpEE44Ana2Xro1284hnyVpBb62lIpU5k85D8xXxatT+rXxBgPkc7C1XwkZMWpK5rXLXTh9PFipWsA=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.1.1", "", { "os": "linux", "cpu": "x64" }, "sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.0.7", "", { "os": "linux", "cpu": "x64" }, "sha512-HYlhqIP6kBPXalW2dbMTSuB4+8fe+j9juyxwfMwCe9kQPPeiyFn7NMjNfoFOfJ2eXkeQsoUGXg+O2SE3m4Qg2w=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.1.1", "", { "os": "linux", "cpu": "x64" }, "sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.0.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-EviG+43iOoBRZg9deGauXExjRphhuYmIOJ12b9sAPy0eQ6iwcPxfED2asb/s2/yiLYOdm37kPaiZu8uXSYPs0Q=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.1.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.0.7", "", { "os": "win32", "cpu": "x64" }, "sha512-gniPjy55zp5Eg0896qSrf3yB1dw4F/3s8VK1ephdsZZ129j2n6e1WqCbE2YgcKhW9hPB9TVZENugquWJD5x0ug=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.1.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Ncwbw2WJ57Al5OX0k4chM68DKhEPlrXBaSXDCi2kPi5f4d8b3ejr3RRJGfKBLrn2YJL5ezNS7w2TZLHSti8CMw=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -148,6 +149,10 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
+
+    "@paper-design/shaders": ["@paper-design/shaders@0.0.68", "", {}, "sha512-HWDb/mYfIDcwRGYjwTFEoupw4PgdmuoNONJ6TIXBaXWj3zdhS38iNehbAWQxWa1NHtOanOeQkbdG0wvaNKhvEw=="],
+
+    "@paper-design/shaders-react": ["@paper-design/shaders-react@0.0.68", "", { "dependencies": { "@paper-design/shaders": "0.0.68" }, "peerDependencies": { "@types/react": "^18 || ^19", "react": "^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-RaL/OCfaPVyVcPHJnemRuobfgseq1Pb5d4ktjclCmKprUe5Ac5WsexFuJBHpIfrMdYC/bV2ADJj24+dnthTpig=="],
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
@@ -296,6 +301,8 @@
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.9.11", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ=="],
 
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
@@ -613,7 +620,7 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
-    "next": ["next@16.0.7", "", { "dependencies": { "@next/env": "16.0.7", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.0.7", "@next/swc-darwin-x64": "16.0.7", "@next/swc-linux-arm64-gnu": "16.0.7", "@next/swc-linux-arm64-musl": "16.0.7", "@next/swc-linux-x64-gnu": "16.0.7", "@next/swc-linux-x64-musl": "16.0.7", "@next/swc-win32-arm64-msvc": "16.0.7", "@next/swc-win32-x64-msvc": "16.0.7", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": "dist/bin/next" }, "sha512-3mBRJyPxT4LOxAJI6IsXeFtKfiJUbjCLgvXO02fV8Wy/lIhPvP94Fe7dGhUgHXcQy4sSuYwQNcOLhIfOm0rL0A=="],
+    "next": ["next@16.1.1", "", { "dependencies": { "@next/env": "16.1.1", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.8.3", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.1.1", "@next/swc-darwin-x64": "16.1.1", "@next/swc-linux-arm64-gnu": "16.1.1", "@next/swc-linux-arm64-musl": "16.1.1", "@next/swc-linux-x64-gnu": "16.1.1", "@next/swc-linux-x64-musl": "16.1.1", "@next/swc-win32-arm64-msvc": "16.1.1", "@next/swc-win32-x64-msvc": "16.1.1", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -806,8 +813,6 @@
     "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": "bin/resolve" }, "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA=="],
-
-    "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@paper-design/shaders-react": "^0.0.68",
     "framer-motion": "^12.23.25",
     "next": "^16.0.10",
     "react": "^19.0.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -82,6 +82,11 @@
   --text-display--letter-spacing: -0.04em;
   --text-display--font-weight: 700;
 
+  --text-h1: clamp(2.25rem, 5vw, 2.75rem);
+  --text-h1--line-height: 1.05;
+  --text-h1--letter-spacing: -0.03em;
+  --text-h1--font-weight: 700;
+
   --text-h2: 1.625rem;
   --text-h2--line-height: 1.15;
   --text-h2--letter-spacing: -0.02em;
@@ -133,6 +138,11 @@
   color: var(--primary);
 }
 
+.type-h1 {
+  @apply text-h1 font-bold;
+  color: var(--primary);
+}
+
 .type-h2 {
   @apply text-h2 font-semibold;
   color: var(--primary);
@@ -145,6 +155,11 @@
 
 .type-body {
   @apply text-body;
+  color: var(--secondary);
+}
+
+.type-body-medium {
+  @apply text-body font-medium;
   color: var(--secondary);
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,29 +19,7 @@
   --success: #059669;
   --warning: #f59e0b;
   
-  /* Spacing scale */
-  --space-xs: 0.25rem;
-  --space-sm: 0.5rem;
-  --space-md: 1rem;
-  --space-lg: 1.5rem;
-  --space-xl: 2rem;
-  --space-2xl: 3rem;
-  --space-3xl: 4rem;
-  
-  /* Typography scale */
-  --text-xs: 0.75rem;
-  --text-sm: 0.875rem;
-  --text-base: 1rem;
-  --text-lg: 1.125rem;
-  --text-xl: 1.25rem;
-  --text-2xl: 1.5rem;
-  --text-3xl: 1.875rem;
-  --text-4xl: 2.25rem;
-  
-  /* Line heights */
-  --leading-tight: 1.25;
-  --leading-normal: 1.5;
-  --leading-relaxed: 1.75;
+  /* Note: Spacing, typography, and line-height tokens are now in @theme inline block */
   
   /* Shadows */
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
@@ -55,6 +33,7 @@
 }
 
 @theme inline {
+  /* Colors (existing) */
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-muted: var(--muted);
@@ -69,11 +48,100 @@
   --color-tertiary: var(--tertiary);
   --color-success: var(--success);
   --color-warning: var(--warning);
-  --font-sans: var(--font-geist-sans);
+
+  /* Fonts - switch to Inter */
+  --font-sans: var(--font-inter);
   --font-mono: var(--font-geist-mono);
+
+  /* Typography - font sizes with bundled properties */
+  --text-display: clamp(2.75rem, 8vw, 4.5rem);
+  --text-display--line-height: 0.95;
+  --text-display--letter-spacing: -0.04em;
+  --text-display--font-weight: 700;
+
+  --text-h2: 1.625rem;
+  --text-h2--line-height: 1.15;
+  --text-h2--letter-spacing: -0.02em;
+
+  --text-h3: 1.125rem;
+  --text-h3--line-height: 1.3;
+
+  --text-body: 1.125rem;
+  --text-body--line-height: 1.65;
+
+  --text-body-sm: 0.9375rem;
+  --text-body-sm--line-height: 1.5;
+
+  --text-caption: 0.8125rem;
+  --text-caption--line-height: 1.5;
+
+  --text-label: 0.6875rem;
+  --text-label--line-height: 1.5;
+  --text-label--letter-spacing: 0.02em;
+
+  /* Line heights (for standalone use) */
+  --leading-display: 0.95;
+  --leading-tight: 1.15;
+  --leading-snug: 1.3;
+  --leading-normal: 1.5;
+  --leading-relaxed: 1.65;
+
+  /* Letter spacing (for standalone use) */
+  --tracking-tighter: -0.04em;
+  --tracking-tight: -0.02em;
+  --tracking-normal: 0;
+  --tracking-wide: 0.02em;
+
+  /* Spacing */
+  --spacing-2xs: 0.125rem;
+  --spacing-xs: 0.25rem;
+  --spacing-sm: 0.5rem;
+  --spacing-md: 1rem;
+  --spacing-lg: 1.5rem;
+  --spacing-xl: 2rem;
+  --spacing-2xl: 3rem;
+  --spacing-3xl: 4rem;
+  --spacing-4xl: 6rem;
 }
 
-@media (prefers-color-scheme: dark) {
+/* Composed typography classes */
+.type-display {
+  @apply text-display font-bold;
+  color: var(--primary);
+}
+
+.type-h2 {
+  @apply text-h2 font-semibold;
+  color: var(--primary);
+}
+
+.type-h3 {
+  @apply text-h3 font-semibold;
+  color: var(--primary);
+}
+
+.type-body {
+  @apply text-body;
+  color: var(--secondary);
+}
+
+.type-body-sm {
+  @apply text-body-sm;
+  color: var(--secondary);
+}
+
+.type-caption {
+  @apply text-caption;
+  color: var(--tertiary);
+}
+
+.type-label {
+  @apply text-label;
+  color: var(--tertiary);
+}
+
+/* Dark mode disabled for portfolio - design is always light mode */
+/* @media (prefers-color-scheme: dark) {
   :root {
     --background: #0f0f0f;
     --foreground: #f8fafc;
@@ -89,7 +157,7 @@
     --success: #10b981;
     --warning: #fbbf24;
   }
-}
+} */
 
 /* Base styles */
 * {
@@ -106,8 +174,8 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: var(--font-sans), system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  font-size: var(--text-base);
-  line-height: var(--leading-normal);
+  font-size: 1rem;
+  line-height: 1.5;
   margin: 0;
   padding: 0;
   min-height: 100vh;
@@ -116,14 +184,14 @@ body {
 /* Typography improvements */
 h1, h2, h3, h4, h5, h6 {
   font-weight: 600;
-  line-height: var(--leading-tight);
+  line-height: 1.15;
   letter-spacing: -0.025em;
   margin: 0 0 24px 0;
 }
 
 p {
   margin: 0 0 12px 0;
-  line-height: var(--leading-relaxed);
+  line-height: 1.65;
 }
 
 /* Focus styles for accessibility */
@@ -149,73 +217,9 @@ a:hover {
   color: var(--secondary);
 }
 
-/* Semantic typography classes */
-.text-hero {
-  font-size: var(--text-4xl);
-  font-weight: 700;
-  line-height: var(--leading-tight);
-  letter-spacing: -0.05em;
-}
-
-.text-h1 {
-  font-size: var(--text-3xl);
-  font-weight: 600;
-  line-height: var(--leading-tight);
-  letter-spacing: -0.025em;
-}
-
-.text-h2 {
-  font-size: var(--text-2xl);
-  font-weight: 600;
-  line-height: var(--leading-tight);
-  letter-spacing: -0.025em;
-}
-
-.text-h3 {
-  font-size: var(--text-xl);
-  font-weight: 600;
-  line-height: var(--leading-tight);
-}
-
-.text-body {
-  font-size: var(--text-lg);
-  line-height: var(--leading-relaxed);
-}
-
-.text-body-sm {
-  font-size: var(--text-base);
-  line-height: var(--leading-normal);
-}
-
-.text-caption {
-  font-size: var(--text-sm);
-  line-height: var(--leading-normal);
-}
-
-/* Semantic color classes */
-.text-primary {
-  color: var(--primary);
-}
-
-.text-secondary {
-  color: var(--secondary);
-}
-
-.text-tertiary {
-  color: var(--tertiary);
-}
-
-.text-accent {
-  color: var(--accent);
-}
-
-.text-success {
-  color: var(--success);
-}
-
-.text-warning {
-  color: var(--warning);
-}
+/* Legacy semantic classes removed - now using @theme inline tokens:
+   text-display, text-h2, text-h3, text-body, text-body-sm, text-caption, text-label
+   Colors: text-primary, text-secondary, text-tertiary via --color-* in @theme */
 
 .bg-surface {
   background-color: var(--muted);
@@ -240,12 +244,12 @@ a:hover {
 /* Layout utility classes */
 .case-study-container {
   min-height: 100vh;
-  padding: var(--space-2xl) var(--space-lg);
+  padding: 3rem 1.5rem;
 }
 
 @media (min-width: 640px) {
   .case-study-container {
-    padding: var(--space-3xl) var(--space-2xl);
+    padding: 4rem 3rem;
   }
 }
 
@@ -255,24 +259,24 @@ a:hover {
 }
 
 .case-study-section {
-  margin-top: var(--space-3xl);
+  margin-top: 4rem;
 }
 
 /* Spacing utility classes */
 .section-spacing {
   display: flex;
   flex-direction: column;
-  gap: var(--space-lg);
+  gap: 1.5rem;
 }
 
 .item-spacing {
   display: flex;
   flex-direction: column;
-  gap: var(--space-md);
+  gap: 1rem;
 }
 
 .tight-spacing {
   display: flex;
   flex-direction: column;
-  gap: var(--space-sm);
+  gap: 0.5rem;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,31 +1,54 @@
 @import "tailwindcss";
 
 :root {
-  /* Colors - Premium designer palette */
-  --background: #fefefe;
-  --foreground: #1a1d23;
-  --muted: #f8f9fa;
-  --muted-foreground: #6b7280;
-  --muted-tertiary: #9ca3af;
-  --border: #e5e7eb;
+  /* Neutral scale (Zinc-based, slightly warm) */
+  --neutral-50: #fafafa;
+  --neutral-100: #f4f4f5;
+  --neutral-200: #e4e4e7;
+  --neutral-300: #d4d4d8;
+  --neutral-400: #a1a1aa;
+  --neutral-500: #71717a;
+  --neutral-600: #52525b;
+  --neutral-700: #3f3f46;
+  --neutral-800: #27272a;
+  --neutral-900: #18181b;
+  --neutral-950: #09090b;
+
+  /* Semantic color mapping */
+  --background: var(--neutral-50);
+  --foreground: var(--neutral-900);
+  --muted: var(--neutral-100);
+  --muted-foreground: var(--neutral-600);
+  --muted-tertiary: var(--neutral-400);
+  --border: var(--neutral-200);
+
+  /* Accent - swap this for personality later */
   --accent: #2563eb;
   --accent-foreground: #ffffff;
+  --accent-interactive: #9A36B2;
+  --accent-interactive-bg: rgba(154, 54, 178, 0.08);
+  --accent-interactive-bg-hover: rgba(154, 54, 178, 0.14);
   --warm-accent: #f59e0b;
-  
-  /* Semantic colors */
-  --primary: #1a1d23;
-  --secondary: #6b7280;
-  --tertiary: #9ca3af;
+
+  /* AI loading gradient */
+  --ai-gradient-1: #A6E5E7;
+  --ai-gradient-2: #64D2D7;
+  --ai-gradient-3: #9A36B2;
+
+  /* Semantic text colors */
+  --primary: var(--neutral-900);
+  --secondary: var(--neutral-600);
+  --tertiary: var(--neutral-400);
+
+  /* Status colors */
   --success: #059669;
   --warning: #f59e0b;
-  
-  /* Note: Spacing, typography, and line-height tokens are now in @theme inline block */
-  
+
   /* Shadows */
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-  
+
   /* Border radius */
   --radius-sm: 0.375rem;
   --radius-md: 0.5rem;
@@ -51,7 +74,7 @@
 
   /* Fonts - switch to Inter */
   --font-sans: var(--font-inter);
-  --font-mono: var(--font-geist-mono);
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 
   /* Typography - font sizes with bundled properties */
   --text-display: clamp(2.75rem, 8vw, 4.5rem);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,27 +1,11 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono, IBM_Plex_Sans, Inter } from "next/font/google";
+import { Inter } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
-
-const ibmPlexSans = IBM_Plex_Sans({
-  variable: "--font-ibm-plex-sans",
-  subsets: ["latin"],
-  weight: ["400", "500", "600"],
-});
 
 const inter = Inter({
   variable: "--font-inter",
   subsets: ["latin"],
-  weight: ["400", "600"],
+  weight: ["400", "500", "600"],
 });
 
 export const metadata: Metadata = {
@@ -52,7 +36,7 @@ export default function RootLayout({
         <link href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined" rel="stylesheet" />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} ${ibmPlexSans.variable} ${inter.variable} antialiased`}
+        className={`${inter.variable} antialiased`}
       >
         {children}
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,11 +14,13 @@ export default function Home() {
       <HeroVignette />
 
       {/* Vignettes Introduction */}
-      <SectionHeader title="Selected Work">
-        <p className="type-body">
-          Product design at Culture Amp
-        </p>
-      </SectionHeader>
+      <section className="w-full pb-10 lg:pb-12 px-6 lg:px-12">
+        <div className="max-w-5xl mx-auto border-t border-gray-200/80 pt-10 lg:pt-12">
+          <h2 className="type-h2">
+            Selected work from Culture Amp
+          </h2>
+        </div>
+      </section>
 
       {/* Vignettes Section */}
       <section className="w-full pb-16 lg:pb-24 px-6 lg:px-12">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,36 +4,19 @@ import PrototypingVignette from '@/components/vignettes/prototyping/PrototypingV
 import VibeCodingVignette from '@/components/vignettes/vibe-coding/VibeCodingVignette';
 import MultilingualVignette from '@/components/vignettes/multilingual/MultilingualVignette';
 import HomeConnectVignette from '@/components/vignettes/home-connect/HomeConnectVignette';
-import ShaderBackground from '@/components/ShaderBackground';
+import HeroVignette from '@/components/vignettes/hero/HeroVignette';
 import SectionHeader from '@/components/SectionHeader';
 
 export default function Home() {
   return (
     <main className="w-full min-h-screen bg-background text-primary">
       {/* Hero Section */}
-      <section className="w-full py-16 lg:py-24 px-6 lg:px-12">
-        <div className="relative max-w-5xl w-full mx-auto">
-          <ShaderBackground />
-          <div className="space-y-5 lg:space-y-7">
-            <h1 className="type-display">
-              Idam Adam
-            </h1>
-            <p className="type-body">
-              Product designer · Maker
-            </p>
-          </div>
-        </div>
-      </section>
+      <HeroVignette />
 
       {/* Vignettes Introduction */}
       <SectionHeader title="Selected Work">
         <p className="type-body">
           Product design at Culture Amp
-        </p>
-        <p className="type-body">
-          I&apos;m a big believer in showing rather than telling, so I prototype until ideas feel
-          real. Click through and play with each feature—these vignettes are built to be tried, not
-          just read about.
         </p>
       </SectionHeader>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ import SectionHeader from '@/components/SectionHeader';
 
 export default function Home() {
   return (
-    <main className="w-full min-h-screen bg-white text-primary">
+    <main className="w-full min-h-screen bg-background text-primary">
       {/* Hero Section */}
       <section className="w-full py-16 lg:py-24 px-6 lg:px-12">
         <div className="relative max-w-5xl w-full mx-auto">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,47 +6,48 @@ import MultilingualVignette from '@/components/vignettes/multilingual/Multilingu
 import HomeConnectVignette from '@/components/vignettes/home-connect/HomeConnectVignette';
 import HeroVignette from '@/components/vignettes/hero/HeroVignette';
 import SectionHeader from '@/components/SectionHeader';
-
 export default function Home() {
   return (
-    <main className="w-full min-h-screen bg-background text-primary">
-      {/* Hero Section */}
-      <HeroVignette />
+    <main className="w-full min-h-screen text-primary bg-background">
+      <div>
+        {/* Hero Section */}
+        <HeroVignette />
 
-      {/* Vignettes Introduction */}
-      <section className="w-full pb-10 lg:pb-12 px-6 lg:px-12">
-        <div className="max-w-5xl mx-auto border-t border-gray-200/80 pt-10 lg:pt-12">
-          <h2 className="type-h2">
-            Selected work from Culture Amp
-          </h2>
-        </div>
-      </section>
+        {/* Vignettes Introduction */}
+        <section className="w-full pb-10 lg:pb-12 px-6 lg:px-12">
+          <div className="max-w-5xl mx-auto border-t border-gray-200/80 pt-10 lg:pt-12">
+            <h2 className="type-h2">
+              Selected work from Culture Amp
+            </h2>
+          </div>
+        </section>
 
-      {/* Vignettes Section */}
-      <section className="w-full pb-16 lg:pb-24 px-6 lg:px-12">
-        <div className="max-w-5xl mx-auto space-y-12 lg:space-y-14">
-          <AIHighlightsVignette />
-          <AISuggestionsVignette />
-          <PrototypingVignette />
-          <MultilingualVignette />
-          <HomeConnectVignette />
-        </div>
-      </section>
+        {/* Vignettes Section */}
+        <section className="w-full pb-16 lg:pb-24 px-6 lg:px-12">
+          <div className="max-w-5xl mx-auto space-y-12 lg:space-y-14">
+            <AIHighlightsVignette />
+            <AISuggestionsVignette />
+            <PrototypingVignette />
+            <MultilingualVignette />
+            <HomeConnectVignette />
+          </div>
+        </section>
 
-      {/* Explorations Section Header */}
-      <SectionHeader title="Explorations">
-        <p className="type-body">
-          Personal products I design and build end-to-end. These projects help me
-          understand technology at a deeper level while exploring entrepreneurial ideas.
-        </p>
-      </SectionHeader>
+        {/* Explorations Section Header */}
+        <SectionHeader title="Explorations">
+          <p className="type-body">
+            Personal products I design and build end-to-end. These projects help me
+            understand technology at a deeper level while exploring entrepreneurial ideas.
+          </p>
+        </SectionHeader>
 
-      {/* Explorations Vignettes */}
-      <section className="w-full pb-20 lg:pb-28 px-6 lg:px-12">
-        <div className="max-w-5xl mx-auto space-y-12 lg:space-y-14">
-          <VibeCodingVignette />
-        </div>
-      </section>
+        {/* Explorations Vignettes */}
+        <section className="w-full pb-20 lg:pb-28 px-6 lg:px-12">
+          <div className="max-w-5xl mx-auto space-y-12 lg:space-y-14">
+            <VibeCodingVignette />
+          </div>
+        </section>
+      </div>
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,16 +9,16 @@ import SectionHeader from '@/components/SectionHeader';
 
 export default function Home() {
   return (
-    <main className="w-full min-h-screen bg-white text-[#0f172a]">
+    <main className="w-full min-h-screen bg-white text-primary">
       {/* Hero Section */}
       <section className="w-full py-16 lg:py-24 px-6 lg:px-12">
         <div className="relative max-w-5xl w-full mx-auto">
           <ShaderBackground />
           <div className="space-y-5 lg:space-y-7">
-            <h1 className="text-[clamp(44px,8vw,72px)] leading-[0.95] tracking-[-0.04em] font-bold text-[#0f172a]">
+            <h1 className="type-display">
               Idam Adam
             </h1>
-            <p className="text-[clamp(18px,3vw,22px)] leading-[1.6] text-[#4b5563] max-w-2xl">
+            <p className="type-body">
               Product designer · Maker
             </p>
           </div>
@@ -27,10 +27,10 @@ export default function Home() {
 
       {/* Vignettes Introduction */}
       <SectionHeader title="Selected Work">
-        <p className="text-[18px] leading-[1.7] text-[#4b5563] font-[family-name:var(--font-ibm-plex-sans)] max-w-3xl">
+        <p className="type-body">
           Product design at Culture Amp
         </p>
-        <p className="text-[18px] leading-[1.7] text-[#4b5563] font-[family-name:var(--font-ibm-plex-sans)] max-w-3xl">
+        <p className="type-body">
           I&apos;m a big believer in showing rather than telling, so I prototype until ideas feel
           real. Click through and play with each feature—these vignettes are built to be tried, not
           just read about.
@@ -50,7 +50,7 @@ export default function Home() {
 
       {/* Explorations Section Header */}
       <SectionHeader title="Explorations">
-        <p className="text-[18px] leading-[1.7] text-[#4b5563] font-[family-name:var(--font-ibm-plex-sans)] max-w-3xl">
+        <p className="type-body">
           Personal products I design and build end-to-end. These projects help me
           understand technology at a deeper level while exploring entrepreneurial ideas.
         </p>

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -9,7 +9,7 @@ export default function SectionHeader({ title, children }: SectionHeaderProps) {
   return (
     <section className="w-full pb-10 lg:pb-12 px-6 lg:px-12">
       <div className="max-w-5xl mx-auto border-t border-gray-200/80 pt-10 lg:pt-12 space-y-3">
-        <h2 className="text-[24px] lg:text-[26px] leading-[1.2] tracking-[-0.02em] font-semibold text-[#0f172a]">
+        <h2 className="type-h2">
           {title}
         </h2>
         {children}

--- a/src/components/demos/RichTextEditor.tsx
+++ b/src/components/demos/RichTextEditor.tsx
@@ -30,13 +30,13 @@ export default function RichTextEditor({
         <div className="bg-white flex items-center gap-1.5 p-1.5">
           {/* Text formatting */}
           <button className="bg-white hover:bg-gray-50 p-3.5 rounded-lg size-12 flex items-center justify-center transition-colors">
-            <span className="material-icons-outlined text-[20px] text-[#2f2438]">format_bold</span>
+            <span className="material-icons-outlined text-h3 text-primary">format_bold</span>
           </button>
           <button className="bg-white hover:bg-gray-50 p-3.5 rounded-lg size-12 flex items-center justify-center transition-colors">
-            <span className="material-icons-outlined text-[20px] text-[#2f2438]">format_italic</span>
+            <span className="material-icons-outlined text-h3 text-primary">format_italic</span>
           </button>
           <button className="bg-white hover:bg-gray-50 p-3.5 rounded-lg size-12 flex items-center justify-center transition-colors">
-            <span className="material-icons-outlined text-[20px] text-[#2f2438]">format_underlined</span>
+            <span className="material-icons-outlined text-h3 text-primary">format_underlined</span>
           </button>
 
           {/* Divider */}
@@ -44,7 +44,7 @@ export default function RichTextEditor({
 
           {/* List button */}
           <button className="bg-white hover:bg-gray-50 p-3.5 rounded-lg size-12 flex items-center justify-center transition-colors">
-            <span className="material-icons-outlined text-[20px] text-[#2f2438]">format_list_bulleted</span>
+            <span className="material-icons-outlined text-h3 text-primary">format_list_bulleted</span>
           </button>
 
           {/* Divider */}
@@ -69,7 +69,7 @@ export default function RichTextEditor({
                 ease: 'easeInOut'
               } : undefined}
             >
-              <span className="material-icons-outlined text-[20px] text-[#9A36B2]">auto_awesome</span>
+              <span className="material-icons-outlined text-h3 text-[#9A36B2]">auto_awesome</span>
               <span className="text-sm font-medium text-[#9A36B2]">Improve</span>
             </motion.button>
           )}
@@ -81,11 +81,11 @@ export default function RichTextEditor({
         {/* Content Area */}
         <div className="bg-white p-3.5 min-h-[80px]">
           {content ? (
-            <p className="text-base leading-6 text-[#2f2438] whitespace-pre-wrap">
+            <p className="text-base leading-6 text-primary whitespace-pre-wrap">
               {content}
             </p>
           ) : (
-            <p className="text-base text-[rgba(47,36,56,0.7)]">{placeholder}</p>
+            <p className="text-base text-secondary">{placeholder}</p>
           )}
         </div>
       </div>

--- a/src/components/demos/RichTextEditor.tsx
+++ b/src/components/demos/RichTextEditor.tsx
@@ -55,7 +55,11 @@ export default function RichTextEditor({
             <motion.button
               onClick={onImprove}
               disabled={isImproving}
-              className="flex items-center gap-1.5 h-10 px-3 py-2 rounded-full bg-[rgba(154,54,178,0.08)] hover:bg-[rgba(154,54,178,0.14)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex items-center gap-1.5 h-10 px-3 py-2 rounded-full transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              style={{
+                backgroundColor: 'var(--accent-interactive-bg)',
+              }}
+              whileHover={{ backgroundColor: 'var(--accent-interactive-bg-hover)' }}
               animate={pulseImproveButton ? {
                 boxShadow: [
                   '0 0 0 0 rgba(154, 54, 178, 0)',
@@ -69,8 +73,8 @@ export default function RichTextEditor({
                 ease: 'easeInOut'
               } : undefined}
             >
-              <span className="material-icons-outlined text-h3 text-[#9A36B2]">auto_awesome</span>
-              <span className="text-sm font-medium text-[#9A36B2]">Improve</span>
+              <span className="material-icons-outlined text-h3" style={{ color: 'var(--accent-interactive)' }}>auto_awesome</span>
+              <span className="text-sm font-medium" style={{ color: 'var(--accent-interactive)' }}>Improve</span>
             </motion.button>
           )}
         </div>

--- a/src/components/vignettes/VignetteContainer.tsx
+++ b/src/components/vignettes/VignetteContainer.tsx
@@ -10,6 +10,7 @@ interface VignetteContainerProps {
   children: ReactNode;
   id: string;
   allowOverflow?: boolean;
+  className?: string;
 }
 
 export default function VignetteContainer({
@@ -17,14 +18,15 @@ export default function VignetteContainer({
   subtitle,
   children,
   id,
-  allowOverflow = false
+  allowOverflow = false,
+  className = ''
 }: VignetteContainerProps) {
   return (
     <motion.article
       id={id}
       className={`w-full bg-white rounded-2xl border border-gray-200/80 ${
         allowOverflow ? 'overflow-visible' : 'overflow-hidden'
-      }`}
+      } ${className}`}
       {...fadeInUp}
     >
       <div className="p-7 lg:p-10 space-y-10">

--- a/src/components/vignettes/VignetteContainer.tsx
+++ b/src/components/vignettes/VignetteContainer.tsx
@@ -31,11 +31,11 @@ export default function VignetteContainer({
         {/* Title Section - Only show if title is provided */}
         {title && (
           <div className="space-y-3">
-            <h2 className="text-[24px] lg:text-[26px] leading-[1.2] tracking-[-0.02em] font-semibold text-[#0f172a]">
+            <h2 className="type-h2">
               {title}
             </h2>
             {subtitle && (
-              <p className="text-[16px] leading-[1.6] text-gray-600 max-w-3xl">
+              <p className="type-body-sm">
                 {subtitle}
               </p>
             )}

--- a/src/components/vignettes/VignetteSplit.tsx
+++ b/src/components/vignettes/VignetteSplit.tsx
@@ -7,27 +7,32 @@ interface VignetteSplitProps {
   description?: ReactNode;
   actions?: ReactNode;
   children: ReactNode;
+  variant?: 'default' | 'hero';
 }
 
 export default function VignetteSplit({
   title,
   description,
   actions,
-  children
+  children,
+  variant = 'default'
 }: VignetteSplitProps) {
   const hasTitle = Boolean(title);
   const textStackClass = hasTitle ? 'space-y-4' : 'space-y-3';
+
+  const titleClass = variant === 'hero' ? 'type-h1' : 'type-h2';
+  const descriptionClass = variant === 'hero' ? 'type-body-medium' : 'type-body';
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-[360px_1fr] xl:grid-cols-[400px_1fr] gap-10 lg:gap-12 lg:items-center">
       <div className={textStackClass}>
         {title && (
-          <h3 className="type-h2">
+          <h3 className={titleClass}>
             {title}
           </h3>
         )}
         {description && (
-          <p className="type-body">
+          <p className={descriptionClass}>
             {description}
           </p>
         )}

--- a/src/components/vignettes/VignetteSplit.tsx
+++ b/src/components/vignettes/VignetteSplit.tsx
@@ -22,12 +22,12 @@ export default function VignetteSplit({
     <div className="grid grid-cols-1 lg:grid-cols-[360px_1fr] xl:grid-cols-[400px_1fr] gap-10 lg:gap-12 lg:items-center">
       <div className={textStackClass}>
         {title && (
-          <h3 className="text-[26px] lg:text-[28px] leading-[1.15] tracking-[-0.02em] font-semibold text-[#0f172a] font-[family-name:var(--font-ibm-plex-sans)]">
+          <h3 className="type-h2">
             {title}
           </h3>
         )}
         {description && (
-          <p className="text-[18px] leading-[1.6] text-[#4b5563] font-[family-name:var(--font-ibm-plex-sans)] max-w-xl">
+          <p className="type-body">
             {description}
           </p>
         )}

--- a/src/components/vignettes/VignetteStaged.tsx
+++ b/src/components/vignettes/VignetteStaged.tsx
@@ -59,11 +59,11 @@ function VignetteStagedInner({
             {/* Iterations header */}
             {currentStageContent?.title && (
               <div className="space-y-3">
-                <h3 className="text-[26px] lg:text-[28px] leading-[1.15] tracking-[-0.02em] font-semibold text-[#0f172a] font-[family-name:var(--font-ibm-plex-sans)]">
+                <h3 className="type-h2">
                   {currentStageContent.title}
                 </h3>
                 {currentStageContent.description && (
-                  <p className="text-[18px] leading-[1.6] text-[#4b5563] font-[family-name:var(--font-ibm-plex-sans)] max-w-xl">
+                  <p className="type-body">
                     {currentStageContent.description}
                   </p>
                 )}
@@ -75,11 +75,11 @@ function VignetteStagedInner({
             {/* Reset button */}
             <motion.button
               onClick={reset}
-              className="flex items-center gap-2 text-[16px] text-[#4b5563] hover:text-[#0f172a] transition-colors font-[family-name:var(--font-ibm-plex-sans)]"
+              className="flex items-center gap-2 type-body-sm hover:text-primary transition-colors"
               whileHover={{ x: -4 }}
               transition={{ duration: 0.2 }}
             >
-              <span className="material-icons-outlined text-[20px]">replay</span>
+              <span className="material-icons-outlined text-h3">replay</span>
               Watch again
             </motion.button>
           </motion.div>
@@ -107,12 +107,12 @@ function VignetteStagedInner({
                 >
                   <button
                     onClick={goToDesignNotes}
-                    className="flex items-center gap-2 text-[16px] text-[#4b5563] hover:text-[#0f172a] transition-colors font-[family-name:var(--font-ibm-plex-sans)] group"
+                    className="flex items-center gap-2 type-body-sm hover:text-primary transition-colors group"
                   >
-                    <span className="material-icons-outlined text-[20px]">auto_awesome</span>
+                    <span className="material-icons-outlined text-h3">auto_awesome</span>
                     <span>{stages.solution.cta}</span>
                     <motion.span
-                      className="material-icons-outlined text-[18px]"
+                      className="material-icons-outlined text-body"
                       initial={{ x: 0 }}
                       whileHover={{ x: 4 }}
                       transition={{ duration: 0.2 }}

--- a/src/components/vignettes/ai-highlights/HighlightsPanel.tsx
+++ b/src/components/vignettes/ai-highlights/HighlightsPanel.tsx
@@ -95,11 +95,11 @@ function LoadingState() {
           border-radius: 7px;
           background: conic-gradient(
             from var(--gradient-angle),
-            #A6E5E7,
-            #64D2D7,
-            #9A36B2,
-            #64D2D7,
-            #A6E5E7
+            var(--ai-gradient-1),
+            var(--ai-gradient-2),
+            var(--ai-gradient-3),
+            var(--ai-gradient-2),
+            var(--ai-gradient-1)
           );
           animation: rotateGradient 3s linear infinite;
           filter: drop-shadow(0 0 20px rgba(166, 229, 231, 0.5));
@@ -247,7 +247,8 @@ function ProblemState({ cards, onTransition }: { cards: FeedbackSource[]; onTran
       <div className="border-t-2 border-gray-200 bg-gray-50 px-5 py-4">
         <motion.button
           onClick={onTransition}
-          className="w-full flex items-center justify-center gap-2 bg-[rgba(154,54,178,0.08)] hover:bg-[rgba(154,54,178,0.14)] px-5 py-3 rounded-full text-[14px] font-semibold transition-colors"
+          className="w-full flex items-center justify-center gap-2 px-5 py-3 rounded-full text-[14px] font-semibold transition-colors"
+          style={{ backgroundColor: 'var(--accent-interactive-bg)' }}
           initial={{ opacity: 0, y: 10 }}
           animate={{
             opacity: 1,
@@ -263,11 +264,11 @@ function ProblemState({ cards, onTransition }: { cards: FeedbackSource[]; onTran
             y: { delay: 0.5, duration: 0.3 },
             boxShadow: { delay: 1, duration: 2.5, repeat: Infinity, ease: 'easeInOut' }
           }}
-          whileHover={{ scale: 1.01 }}
+          whileHover={{ scale: 1.01, backgroundColor: 'var(--accent-interactive-bg-hover)' }}
           whileTap={{ scale: 0.99 }}
         >
-          <span className="material-icons-outlined text-h3 text-[#9A36B2]">auto_awesome</span>
-          <span className="text-[#9A36B2]">Show Highlights and Opportunities</span>
+          <span className="material-icons-outlined text-h3" style={{ color: 'var(--accent-interactive)' }}>auto_awesome</span>
+          <span style={{ color: 'var(--accent-interactive)' }}>Show Highlights and Opportunities</span>
         </motion.button>
       </div>
     </div>
@@ -287,7 +288,7 @@ function SolutionState({ className = '', redlineModeActive = false, focusedAncho
 
   return (
     <div
-      className={`bg-white border-2 border-[#a6e5e7] rounded-lg overflow-hidden font-[family-name:var(--font-inter)] ${className}`}
+      className={`bg-white border-2 border-[#a6e5e7] rounded-lg overflow-hidden ${className}`}
     >
       {/* Header Section */}
       <div

--- a/src/components/vignettes/ai-highlights/HighlightsPanel.tsx
+++ b/src/components/vignettes/ai-highlights/HighlightsPanel.tsx
@@ -44,29 +44,29 @@ function SourceCard({ name, date, context, feedback, avatarUrl }: SourceCardProp
           alt={name}
           className="w-6 h-6 rounded-full"
         />
-        <span className="text-[14px] leading-[18px] font-semibold text-[#2f2438]">
+        <span className="text-body-sm font-semibold text-primary">
           {name}
         </span>
-        <span className="text-[12px] leading-[16px] text-[#524e56]">
+        <span className="text-caption text-secondary">
           {date}
         </span>
-        <span className="text-[12px] leading-[16px] text-[#524e56]">
+        <span className="text-caption text-secondary">
           •
         </span>
-        <span className="text-[12px] leading-[16px] text-[#524e56]">
+        <span className="text-caption text-secondary">
           {context}
         </span>
       </div>
-      <p className="text-[14px] leading-[20px] text-[#2f2438] mb-3">
+      <p className="text-body-sm text-primary mb-3">
         {feedback}
       </p>
       <div className="flex items-center justify-between">
-        <span className="text-[12px] leading-[16px] text-[#524e56]">
+        <span className="text-caption text-secondary">
           Not shared with Idam Adam
         </span>
-        <a href="#" className="text-[14px] leading-[18px] text-[#2f2438] hover:underline inline-flex items-center gap-1">
+        <a href="#" className="text-body-sm text-primary hover:underline inline-flex items-center gap-1">
           View feedback
-          <span className="material-icons-outlined text-[16px]">arrow_forward</span>
+          <span className="material-icons-outlined text-body-sm">arrow_forward</span>
         </a>
       </div>
     </div>
@@ -150,7 +150,7 @@ function LoadingState() {
         <div className="loading-panel-content">
           {/* Header Section */}
           <div className="border-b-2 border-[#eaeaec] px-6 py-8">
-            <p className="text-[16px] leading-[24px] font-semibold text-black mb-3">
+            <p className="text-body-sm font-semibold text-black mb-3">
               Loading highlights and opportunities
             </p>
             <div className="space-y-3">
@@ -196,10 +196,10 @@ function ProblemState({ cards, onTransition }: { cards: FeedbackSource[]; onTran
       {/* Header with count */}
       <div className="bg-gradient-to-r from-gray-50 to-gray-100 border-b-2 border-gray-200 px-5 py-3.5 flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <span className="material-icons-outlined text-[18px] text-gray-700 leading-none">
+          <span className="material-icons-outlined text-body text-gray-700 leading-none">
             inbox
           </span>
-          <div className="text-[15px] font-semibold text-gray-900 leading-none">
+          <div className="text-body-sm font-semibold text-gray-900 leading-none">
             Feedback about Idam
           </div>
         </div>
@@ -227,12 +227,12 @@ function ProblemState({ cards, onTransition }: { cards: FeedbackSource[]; onTran
                   className="w-6 h-6 rounded-full"
                 />
                 {card.from && (
-                  <span className="text-[14px] leading-[18px] font-semibold text-[#2f2438]">
+                  <span className="text-body-sm font-semibold text-primary">
                     {card.from}
                   </span>
                 )}
               </div>
-              <p className="text-[14px] leading-[20px] text-[#2f2438]">
+              <p className="text-body-sm text-primary">
                 {card.content}
               </p>
             </motion.div>
@@ -266,7 +266,7 @@ function ProblemState({ cards, onTransition }: { cards: FeedbackSource[]; onTran
           whileHover={{ scale: 1.01 }}
           whileTap={{ scale: 0.99 }}
         >
-          <span className="material-icons-outlined text-[20px] text-[#9A36B2]">auto_awesome</span>
+          <span className="material-icons-outlined text-h3 text-[#9A36B2]">auto_awesome</span>
           <span className="text-[#9A36B2]">Show Highlights and Opportunities</span>
         </motion.button>
       </div>
@@ -302,15 +302,15 @@ function SolutionState({ className = '', redlineModeActive = false, focusedAncho
             className="w-12 h-12 rounded-full shadow-sm"
           />
           <div>
-            <p className="text-[20px] leading-[30px] font-normal text-[#2f2438]" style={{ marginBottom: '0px' }}>
+            <p className="text-h3 font-normal text-primary" style={{ marginBottom: '0px' }}>
               Idam Adam
             </p>
-            <p className="text-[16px] leading-[24px] text-[#2f2438] mb-0">
+            <p className="text-body-sm text-primary mb-0">
               Lead Product Designer
             </p>
           </div>
         </div>
-        <p className="text-[16px] leading-[24px] text-[#2f2438] mt-0">
+        <p className="text-body-sm text-primary mt-0">
           Idam designed 2 tools to help reduce the burden of the Performance Review Period.
           Highlights & Opportunities helps managers quickly understand what their direct reports
           did & verify AI output using direct quotes from feedback.
@@ -327,14 +327,14 @@ function SolutionState({ className = '', redlineModeActive = false, focusedAncho
           <div className="flex items-start gap-2">
             <div className="flex-1">
               <div className="flex items-center gap-1 mb-2">
-                <span className="material-icons-outlined text-[20px] text-[#22594A]">
+                <span className="material-icons-outlined text-h3 text-[#22594A]">
                   star_outline
                 </span>
-                <span className="text-[16px] leading-[24px] font-semibold text-[#2f2438]">
+                <span className="text-body-sm font-semibold text-primary">
                   Highlight
                 </span>
               </div>
-              <p className="text-[16px] leading-[24px] text-[#2f2438]">
+              <p className="text-body-sm text-primary">
                 Developed a process to get early feedback about model output during user testing.
               </p>
             </div>
@@ -353,7 +353,7 @@ function SolutionState({ className = '', redlineModeActive = false, focusedAncho
                     className="w-5 h-5 rounded-full border-2 border-white"
                   />
                 </div>
-                <span className="text-[14px] leading-[18px] text-[#524e56]">
+                <span className="text-body-sm text-secondary">
                   2 sources
                 </span>
               </div>
@@ -365,7 +365,7 @@ function SolutionState({ className = '', redlineModeActive = false, focusedAncho
                 <motion.span
                   animate={{ rotate: highlightExpanded ? 180 : 0 }}
                   transition={{ duration: 0.3 }}
-                  className="material-icons-outlined text-[20px] text-[#2f2438] block"
+                  className="material-icons-outlined text-h3 text-primary block"
                 >
                   keyboard_arrow_down
                 </motion.span>
@@ -414,14 +414,14 @@ function SolutionState({ className = '', redlineModeActive = false, focusedAncho
           <div className="flex items-start gap-2">
             <div className="flex-1">
               <div className="flex items-center gap-1 mb-2">
-                <span className="material-icons-outlined text-[20px]" style={{ color: 'rgba(135, 100, 0, 1)' }}>
+                <span className="material-icons-outlined text-h3" style={{ color: 'rgba(135, 100, 0, 1)' }}>
                   lightbulb
                 </span>
-                <span className="text-[16px] leading-[24px] font-semibold text-[#2f2438]">
+                <span className="text-body-sm font-semibold text-primary">
                   Opportunity
                 </span>
               </div>
-              <p className="text-[16px] leading-[24px] text-[#2f2438]">
+              <p className="text-body-sm text-primary">
                 Developed a process to get early feedback about model output during user testing.
               </p>
             </div>
@@ -440,7 +440,7 @@ function SolutionState({ className = '', redlineModeActive = false, focusedAncho
                     className="w-5 h-5 rounded-full border-2 border-white"
                   />
                 </div>
-                <span className="text-[14px] leading-[18px] text-[#524e56]">
+                <span className="text-body-sm text-secondary">
                   2 sources
                 </span>
               </div>
@@ -452,7 +452,7 @@ function SolutionState({ className = '', redlineModeActive = false, focusedAncho
                 <motion.span
                   animate={{ rotate: opportunityExpanded ? 180 : 0 }}
                   transition={{ duration: 0.3 }}
-                  className="material-icons-outlined text-[20px] text-[#2f2438] block"
+                  className="material-icons-outlined text-h3 text-primary block"
                 >
                   keyboard_arrow_down
                 </motion.span>
@@ -497,14 +497,14 @@ function SolutionState({ className = '', redlineModeActive = false, focusedAncho
         style={getAnchorStyle('feedback-footer')}
         data-anchor="feedback-footer"
       >
-        <span className="text-[14px] leading-[18px] text-[#524e56]">
+        <span className="text-body-sm text-secondary">
           Is this helpful?
         </span>
         <button
           className="p-2 hover:bg-gray-50 rounded-lg transition-colors"
           aria-label="Thumbs up"
         >
-          <span className="material-icons-outlined text-[24px] text-[#2f2438]">
+          <span className="material-icons-outlined text-h2 text-primary">
             thumb_up
           </span>
         </button>
@@ -512,7 +512,7 @@ function SolutionState({ className = '', redlineModeActive = false, focusedAncho
           className="p-2 hover:bg-gray-50 rounded-lg transition-colors"
           aria-label="Thumbs down"
         >
-          <span className="material-icons-outlined text-[24px] text-[#2f2438]">
+          <span className="material-icons-outlined text-h2 text-primary">
             thumb_down
           </span>
         </button>

--- a/src/components/vignettes/ai-suggestions/SuggestionsPanel.tsx
+++ b/src/components/vignettes/ai-suggestions/SuggestionsPanel.tsx
@@ -39,11 +39,11 @@ function LoadingPanel() {
           border-radius: 7px;
           background: conic-gradient(
             from var(--gradient-angle),
-            #A6E5E7,
-            #64D2D7,
-            #9A36B2,
-            #64D2D7,
-            #A6E5E7
+            var(--ai-gradient-1),
+            var(--ai-gradient-2),
+            var(--ai-gradient-3),
+            var(--ai-gradient-2),
+            var(--ai-gradient-1)
           );
           animation: rotateGradient 3s linear infinite;
           filter: drop-shadow(0 0 20px rgba(166, 229, 231, 0.5));
@@ -100,7 +100,7 @@ function RecommendationsPanel({
         position: 'relative',
         borderRadius: '7px',
         padding: '2px',
-        background: 'linear-gradient(135deg, #A6E5E7, #64D2D7, #9A36B2)',
+        background: 'linear-gradient(135deg, var(--ai-gradient-1), var(--ai-gradient-2), var(--ai-gradient-3))',
       }}
     >
       <div className="recommendation-content bg-white rounded-[5px] p-6 space-y-4">
@@ -181,7 +181,7 @@ export default function SuggestionsPanel({
   const { getAnchorStyle } = useAnchorStyle({ redlineModeActive, focusedAnchor });
 
   return (
-    <div className="space-y-2 font-[family-name:var(--font-inter)]">
+    <div className="space-y-2">
       {/* Editor - always visible */}
       <div
         style={isSolution ? getAnchorStyle('improve-button') : undefined}

--- a/src/components/vignettes/ai-suggestions/SuggestionsPanel.tsx
+++ b/src/components/vignettes/ai-suggestions/SuggestionsPanel.tsx
@@ -69,10 +69,10 @@ function LoadingPanel() {
         <div className="suggestions-loading-border"></div>
         <div className="suggestions-loading-content px-6 py-8">
           <div className="flex items-center gap-2">
-            <span className="material-icons-outlined text-[20px] text-[#2f2438]">
+            <span className="material-icons-outlined text-h3 text-primary">
               auto_awesome
             </span>
-            <span className="text-lg font-semibold text-[#2f2438]">
+            <span className="text-lg font-semibold text-primary">
               Looking for ways to improve...
             </span>
           </div>
@@ -111,14 +111,14 @@ function RecommendationsPanel({
           data-anchor="recommendations-header"
         >
           <div className="flex items-start gap-2">
-            <span className="material-icons-outlined text-[20px] text-[#2f2438] mt-0.5">
+            <span className="material-icons-outlined text-h3 text-primary mt-0.5">
               auto_awesome
             </span>
             <div className="flex flex-col">
-              <span className="text-lg font-semibold text-[#2f2438] leading-6">
+              <span className="text-lg font-semibold text-primary leading-6">
                 {content.recommendations.length} suggested improvements
               </span>
-              <span className="text-sm font-normal text-[#524e56] leading-5">
+              <span className="text-sm font-normal text-secondary leading-5">
                 based on Culture Amp People Science
               </span>
             </div>
@@ -129,7 +129,7 @@ function RecommendationsPanel({
         <div className="space-y-4">
           {content.recommendations.map((rec, index) => (
             <div key={index}>
-              <p className="text-base leading-6 text-[#2f2438]">
+              <p className="text-base leading-6 text-primary">
                 <span className="font-semibold">{rec.title}</span>
                 <span className="font-normal"> {rec.description}</span>
               </p>
@@ -147,19 +147,19 @@ function RecommendationsPanel({
           data-anchor="feedback-footer"
         >
           <div className="flex items-center gap-4">
-            <span className="text-sm text-[#524e56]">Is this helpful?</span>
+            <span className="text-sm text-secondary">Is this helpful?</span>
             <button className="p-2 hover:bg-gray-50 rounded-lg transition-colors">
-              <span className="material-icons-outlined text-[16px] text-[#2f2438]">
+              <span className="material-icons-outlined text-body-sm text-primary">
                 thumb_up
               </span>
             </button>
             <button className="p-2 hover:bg-gray-50 rounded-lg transition-colors">
-              <span className="material-icons-outlined text-[16px] text-[#2f2438]">
+              <span className="material-icons-outlined text-body-sm text-primary">
                 thumb_down
               </span>
             </button>
           </div>
-          <span className="text-sm text-[#524e56]">
+          <span className="text-sm text-secondary">
             Review AI-generated suggestions for accuracy
           </span>
         </div>

--- a/src/components/vignettes/hero/HeroPanel.tsx
+++ b/src/components/vignettes/hero/HeroPanel.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { heroContent, DesignPrinciple } from './content';
+
+interface PrincipleCardProps {
+  principle: DesignPrinciple;
+  isExpanded: boolean;
+  onToggle: () => void;
+}
+
+function PrincipleCard({ principle, isExpanded, onToggle }: PrincipleCardProps) {
+  return (
+    <motion.button
+      onClick={onToggle}
+      className="w-full text-left p-4 rounded-xl border border-gray-200 bg-gray-50/50
+                 hover:bg-gray-100/80 transition-colors cursor-pointer"
+      layout
+      whileHover={{ scale: 1.01 }}
+      whileTap={{ scale: 0.99 }}
+      aria-expanded={isExpanded}
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex-1 space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="font-semibold text-primary">{principle.label}</span>
+            <motion.span
+              className="material-icons-outlined text-body text-secondary"
+              animate={{ rotate: isExpanded ? 180 : 0 }}
+              transition={{ duration: 0.2 }}
+            >
+              expand_more
+            </motion.span>
+          </div>
+          <AnimatePresence>
+            {isExpanded && (
+              <motion.p
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: 'auto' }}
+                exit={{ opacity: 0, height: 0 }}
+                transition={{ duration: 0.25, ease: 'easeOut' }}
+                className="type-body-sm text-secondary"
+              >
+                {principle.detail}
+              </motion.p>
+            )}
+          </AnimatePresence>
+        </div>
+      </div>
+    </motion.button>
+  );
+}
+
+export default function HeroPanel() {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const handleToggle = (id: string) => {
+    setExpandedId(expandedId === id ? null : id);
+  };
+
+  return (
+    <div className="space-y-3">
+      {heroContent.principles.map((principle, index) => (
+        <motion.div
+          key={principle.id}
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.1 + index * 0.1, duration: 0.4 }}
+        >
+          <PrincipleCard
+            principle={principle}
+            isExpanded={expandedId === principle.id}
+            onToggle={() => handleToggle(principle.id)}
+          />
+        </motion.div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/vignettes/hero/HeroShaderPanel.tsx
+++ b/src/components/vignettes/hero/HeroShaderPanel.tsx
@@ -34,7 +34,7 @@ export default function HeroShaderPanel() {
           height={dimensions.height || 300}
           colorBack="#f5f5f5"
           colorFront="#e8e8e8"
-          shape="diamond"
+          shape="dots"
           type="2x2"
           size={2}
           speed={0.25}

--- a/src/components/vignettes/hero/HeroShaderPanel.tsx
+++ b/src/components/vignettes/hero/HeroShaderPanel.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { Dithering } from '@paper-design/shaders-react';
+
+export default function HeroShaderPanel() {
+  const [mounted, setMounted] = useState(false);
+  const [dimensions, setDimensions] = useState({ width: 400, height: 300 });
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setMounted(true);
+    const updateDimensions = () => {
+      if (containerRef.current) {
+        const rect = containerRef.current.getBoundingClientRect();
+        if (rect.width > 0 && rect.height > 0) {
+          setDimensions({ width: rect.width, height: rect.height });
+        }
+      }
+    };
+    updateDimensions();
+    window.addEventListener('resize', updateDimensions);
+    return () => window.removeEventListener('resize', updateDimensions);
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      className="w-full aspect-[4/3] rounded-xl overflow-hidden"
+    >
+      {mounted && (
+        <Dithering
+          width={dimensions.width || 400}
+          height={dimensions.height || 300}
+          colorBack="#f5f5f5"
+          colorFront="#e8e8e8"
+          shape="diamond"
+          type="2x2"
+          size={2}
+          speed={0.25}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/vignettes/hero/HeroVignette.tsx
+++ b/src/components/vignettes/hero/HeroVignette.tsx
@@ -17,6 +17,7 @@ export default function HeroVignette() {
             <VignetteSplit
               title={heroContent.name}
               description={`${heroContent.role}. ${heroContent.tagline}`}
+              variant="hero"
             >
               <div className="space-y-4">
                 <HeroShaderPanel />

--- a/src/components/vignettes/hero/HeroVignette.tsx
+++ b/src/components/vignettes/hero/HeroVignette.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import HeroPanel from './HeroPanel';
+import VignetteContainer from '@/components/vignettes/VignetteContainer';
+import VignetteSplit from '@/components/vignettes/VignetteSplit';
+import { fadeInUp } from '@/lib/animations';
+import { heroContent } from './content';
+
+export default function HeroVignette() {
+  return (
+    <section className="w-full py-16 lg:py-24 px-6 lg:px-12">
+      <div className="max-w-5xl mx-auto">
+        <VignetteContainer id="hero">
+          <motion.div {...fadeInUp} transition={{ delay: 0.1 }}>
+            <VignetteSplit
+              title={heroContent.name}
+              description={`${heroContent.role}. ${heroContent.tagline}`}
+            >
+              <HeroPanel />
+            </VignetteSplit>
+          </motion.div>
+        </VignetteContainer>
+      </div>
+    </section>
+  );
+}

--- a/src/components/vignettes/hero/HeroVignette.tsx
+++ b/src/components/vignettes/hero/HeroVignette.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion';
 import HeroPanel from './HeroPanel';
+import HeroShaderPanel from './HeroShaderPanel';
 import VignetteContainer from '@/components/vignettes/VignetteContainer';
 import VignetteSplit from '@/components/vignettes/VignetteSplit';
 import { fadeInUp } from '@/lib/animations';
@@ -17,7 +18,10 @@ export default function HeroVignette() {
               title={heroContent.name}
               description={`${heroContent.role}. ${heroContent.tagline}`}
             >
-              <HeroPanel />
+              <div className="space-y-4">
+                <HeroShaderPanel />
+                <HeroPanel />
+              </div>
             </VignetteSplit>
           </motion.div>
         </VignetteContainer>

--- a/src/components/vignettes/hero/content.ts
+++ b/src/components/vignettes/hero/content.ts
@@ -1,0 +1,35 @@
+export interface DesignPrinciple {
+  id: string;
+  label: string;
+  detail: string;
+}
+
+export interface HeroContent {
+  name: string;
+  role: string;
+  tagline: string;
+  principles: DesignPrinciple[];
+}
+
+export const heroContent: HeroContent = {
+  name: 'Idam Adam',
+  role: 'Lead Product Designer',
+  tagline: 'I design and build products that show rather than tell.',
+  principles: [
+    {
+      id: 'show-dont-tell',
+      label: 'Show, don\'t tell',
+      detail: 'Prototypes speak louder than decks. Every vignette below is interactive.'
+    },
+    {
+      id: 'technical-empathy',
+      label: 'Technical empathy',
+      detail: 'I code production software. This portfolio is one of them.'
+    },
+    {
+      id: 'start-with-problems',
+      label: 'Start with problems',
+      detail: 'Good design solves real problems. Scroll down to see how.'
+    }
+  ]
+};

--- a/src/components/vignettes/home-connect/HomeConnectPanel.tsx
+++ b/src/components/vignettes/home-connect/HomeConnectPanel.tsx
@@ -70,7 +70,7 @@ function GoalDonut({ percentage }: { percentage: number }) {
         />
       </svg>
       <div className="absolute inset-0 flex items-center justify-center">
-        <span className="text-[11px] font-semibold text-[#2F2438]/70">{percentage}%</span>
+        <span className="text-label font-semibold text-primary/70">{percentage}%</span>
       </div>
     </div>
   );
@@ -80,7 +80,7 @@ function GoalDonut({ percentage }: { percentage: number }) {
 function FeedDivider({ label }: { label: string }) {
   return (
     <div className="flex items-center gap-4 py-1">
-      <span className="text-[13px] font-semibold text-[#2F2438]/60 shrink-0">{label}</span>
+      <span className="text-caption font-semibold text-primary/60 shrink-0">{label}</span>
       <div className="flex-1 h-px bg-[#524E56]/10 rounded-full" />
     </div>
   );
@@ -146,12 +146,12 @@ export default function HomeConnectPanel({
           <svg width="14" height="14" viewBox="0 0 20 20" fill="none">
             <circle cx="10" cy="10" r="8" stroke="white" strokeWidth="2" fill="none" />
           </svg>
-          <span className="text-white text-[11px] font-semibold">Culture Amp</span>
+          <span className="text-white text-label font-semibold">Culture Amp</span>
         </div>
 
         {/* Home title */}
         <motion.h1
-          className="text-white text-[22px] font-bold leading-tight !m-0"
+          className="text-white text-h3 font-bold leading-tight !m-0"
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.1 }}
@@ -169,7 +169,7 @@ export default function HomeConnectPanel({
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.15 }}
         >
-          <h2 className="text-[16px] font-bold text-[#2F2438] leading-tight mb-2">Your feed</h2>
+          <h2 className="text-body-sm font-bold text-primary leading-tight mb-2">Your feed</h2>
 
           <FeedDivider label="Upcoming" />
 
@@ -179,13 +179,13 @@ export default function HomeConnectPanel({
             style={getAnchorStyle('feed-card-performance')}
           >
             <div className="space-y-2">
-              <p className="text-[13px] text-[#2F2438]">
+              <p className="text-caption text-primary">
                 <span className="font-semibold">2023 Performance Cycle</span> feedback closes in 3 days
               </p>
               <div className="flex items-center gap-1.5">
                 <ProgressRing progress={80} />
-                <span className="text-[15px] font-bold text-[#2F2438]">4 of 5</span>
-                <span className="text-[12px] text-[#2F2438]/60">reports with completed feedback</span>
+                <span className="text-body-sm font-bold text-primary">4 of 5</span>
+                <span className="text-caption text-primary/60">reports with completed feedback</span>
               </div>
             </div>
           </FeedCard>
@@ -195,12 +195,12 @@ export default function HomeConnectPanel({
             <div className="space-y-2">
               <div className="flex items-center gap-1.5">
                 <Avatar initials="AP" />
-                <span className="text-[13px] font-semibold text-[#2F2438]">Aisha Patel</span>
-                <span className="text-[13px] text-[#2F2438]">1-on-1 today</span>
+                <span className="text-caption font-semibold text-primary">Aisha Patel</span>
+                <span className="text-caption text-primary">1-on-1 today</span>
               </div>
               <div className="flex items-center gap-1.5">
                 <DownArrowIcon />
-                <span className="text-[12px] font-medium text-[#A82433]">Wellbeing has gone down since last 1-on-1</span>
+                <span className="text-caption font-medium text-[#A82433]">Wellbeing has gone down since last 1-on-1</span>
               </div>
             </div>
           </FeedCard>
@@ -217,10 +217,10 @@ export default function HomeConnectPanel({
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-1.5 mb-1">
                   <Avatar initials="MW" size={16} />
-                  <span className="text-[13px] font-semibold text-[#2F2438]">Malik Williams</span>
-                  <span className="text-[12px] text-[#2F2438]/60">has an inactive goal</span>
+                  <span className="text-caption font-semibold text-primary">Malik Williams</span>
+                  <span className="text-caption text-primary/60">has an inactive goal</span>
                 </div>
-                <p className="text-[12px] text-[#2F2438]">Learn how to handle multiple priorities</p>
+                <p className="text-caption text-primary">Learn how to handle multiple priorities</p>
               </div>
             </div>
           </FeedCard>

--- a/src/components/vignettes/home-connect/ProblemPanel.tsx
+++ b/src/components/vignettes/home-connect/ProblemPanel.tsx
@@ -77,13 +77,13 @@ export default function ProblemPanel({ onTransition }: ProblemPanelProps) {
               >
                 {item.icon}
               </span>
-              <span className="text-[11px] font-medium text-gray-600">
+              <span className="text-label font-medium text-gray-600">
                 {item.page}
               </span>
             </div>
             {/* Page content */}
             <div className="px-2.5 py-2.5 bg-white">
-              <span className="text-[12px] text-[#2F2438] leading-tight block">{item.insight}</span>
+              <span className="text-caption text-primary leading-tight block">{item.insight}</span>
             </div>
           </motion.div>
         ))}
@@ -92,7 +92,7 @@ export default function ProblemPanel({ onTransition }: ProblemPanelProps) {
       {/* CTA */}
       <motion.button
         onClick={onTransition}
-        className="w-full py-3 px-4 rounded-xl text-white font-medium text-[15px] flex items-center justify-center gap-2"
+        className="w-full py-3 px-4 rounded-xl text-white font-medium text-body-sm flex items-center justify-center gap-2"
         style={{ backgroundColor: '#5F3361' }}
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
@@ -101,7 +101,7 @@ export default function ProblemPanel({ onTransition }: ProblemPanelProps) {
         whileTap={{ scale: 0.98 }}
       >
         What if it was all in one place?
-        <span className="material-icons-outlined text-[18px]">arrow_forward</span>
+        <span className="material-icons-outlined text-body">arrow_forward</span>
       </motion.button>
     </div>
   );

--- a/src/components/vignettes/home-connect/ProblemPanel.tsx
+++ b/src/components/vignettes/home-connect/ProblemPanel.tsx
@@ -92,16 +92,28 @@ export default function ProblemPanel({ onTransition }: ProblemPanelProps) {
       {/* CTA */}
       <motion.button
         onClick={onTransition}
-        className="w-full py-3 px-4 rounded-xl text-white font-medium text-body-sm flex items-center justify-center gap-2"
-        style={{ backgroundColor: '#5F3361' }}
+        className="w-full py-3 px-4 rounded-full font-semibold text-body-sm flex items-center justify-center gap-2"
+        style={{ backgroundColor: 'var(--accent-interactive-bg)' }}
         initial={{ opacity: 0, y: 10 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: reducedMotion ? 0 : 0.6 }}
-        whileHover={{ scale: 1.02 }}
+        animate={{
+          opacity: 1,
+          y: 0,
+          boxShadow: [
+            '0 0 0 0 rgba(154, 54, 178, 0)',
+            '0 0 0 6px rgba(154, 54, 178, 0.12)',
+            '0 0 0 0 rgba(154, 54, 178, 0)'
+          ]
+        }}
+        transition={{
+          opacity: { delay: reducedMotion ? 0 : 0.6 },
+          y: { delay: reducedMotion ? 0 : 0.6 },
+          boxShadow: { delay: reducedMotion ? 0 : 1.1, duration: 2.5, repeat: Infinity, ease: 'easeInOut' }
+        }}
+        whileHover={{ scale: 1.02, backgroundColor: 'var(--accent-interactive-bg-hover)' }}
         whileTap={{ scale: 0.98 }}
       >
-        What if it was all in one place?
-        <span className="material-icons-outlined text-body">arrow_forward</span>
+        <span className="material-icons-outlined text-h3" style={{ color: 'var(--accent-interactive)' }}>auto_awesome</span>
+        <span style={{ color: 'var(--accent-interactive)' }}>What if it was all in one place?</span>
       </motion.button>
     </div>
   );

--- a/src/components/vignettes/home-connect/TransitionPanel.tsx
+++ b/src/components/vignettes/home-connect/TransitionPanel.tsx
@@ -86,9 +86,9 @@ export default function TransitionPanel({ onComplete }: TransitionPanelProps) {
           <svg width="14" height="14" viewBox="0 0 20 20" fill="none">
             <circle cx="10" cy="10" r="8" stroke="white" strokeWidth="2" fill="none" />
           </svg>
-          <span className="text-white text-[11px] font-semibold">Culture Amp</span>
+          <span className="text-white text-label font-semibold">Culture Amp</span>
         </div>
-        <h1 className="text-white text-[22px] font-bold leading-tight !m-0">Home</h1>
+        <h1 className="text-white text-h3 font-bold leading-tight !m-0">Home</h1>
       </div>
 
       {/* Cards consolidating area */}
@@ -133,13 +133,13 @@ export default function TransitionPanel({ onComplete }: TransitionPanelProps) {
               >
                 {card.icon}
               </span>
-              <span className="text-[11px] font-medium text-gray-600">
+              <span className="text-label font-medium text-gray-600">
                 {card.page}
               </span>
             </div>
             {/* Page content */}
             <div className="px-2.5 py-2.5 bg-white">
-              <span className="text-[12px] text-[#2F2438] leading-tight block">
+              <span className="text-caption text-primary leading-tight block">
                 {card.insight}
               </span>
             </div>
@@ -150,7 +150,7 @@ export default function TransitionPanel({ onComplete }: TransitionPanelProps) {
       {/* Progress indicator */}
       <div className="px-5 pb-5">
         <motion.div
-          className="flex items-center justify-center gap-2 py-3 text-[15px] text-gray-500"
+          className="flex items-center justify-center gap-2 py-3 text-body-sm text-gray-500"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ delay: 0.2 }}

--- a/src/components/vignettes/multilingual/ProblemPanel.tsx
+++ b/src/components/vignettes/multilingual/ProblemPanel.tsx
@@ -108,16 +108,28 @@ export default function ProblemPanel({ onTransition }: ProblemPanelProps) {
         {stage >= 3 && (
           <motion.button
             onClick={onTransition}
-            className="w-full flex items-center justify-center gap-2 py-3 px-4 rounded-xl text-white font-medium text-body-sm"
-            style={{ backgroundColor: '#0168b3' }}
+            className="w-full flex items-center justify-center gap-2 py-3 px-4 rounded-full font-semibold text-body-sm"
+            style={{ backgroundColor: 'var(--accent-interactive-bg)' }}
             initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.3 }}
-            whileHover={{ scale: 1.02 }}
+            animate={{
+              opacity: 1,
+              y: 0,
+              boxShadow: [
+                '0 0 0 0 rgba(154, 54, 178, 0)',
+                '0 0 0 6px rgba(154, 54, 178, 0.12)',
+                '0 0 0 0 rgba(154, 54, 178, 0)'
+              ]
+            }}
+            transition={{
+              opacity: { duration: 0.3 },
+              y: { duration: 0.3 },
+              boxShadow: { delay: 0.5, duration: 2.5, repeat: Infinity, ease: 'easeInOut' }
+            }}
+            whileHover={{ scale: 1.02, backgroundColor: 'var(--accent-interactive-bg-hover)' }}
             whileTap={{ scale: 0.98 }}
           >
-            See the solution
-            <span className="material-icons-outlined text-body">arrow_forward</span>
+            <span className="material-icons-outlined text-h3" style={{ color: 'var(--accent-interactive)' }}>auto_awesome</span>
+            <span style={{ color: 'var(--accent-interactive)' }}>See the solution</span>
           </motion.button>
         )}
       </AnimatePresence>

--- a/src/components/vignettes/multilingual/ProblemPanel.tsx
+++ b/src/components/vignettes/multilingual/ProblemPanel.tsx
@@ -38,10 +38,10 @@ export default function ProblemPanel({ onTransition }: ProblemPanelProps) {
           <div className="flex items-center gap-3">
             <div className="w-5 h-5 rounded border-2 border-gray-300 flex-shrink-0" />
             <div>
-              <div className="text-[15px] font-medium text-gray-800">
+              <div className="text-body-sm font-medium text-gray-800">
                 Run Q1 Performance Cycle
               </div>
-              <div className="text-[12px] text-gray-400">
+              <div className="text-caption text-gray-400">
                 Admin task
               </div>
             </div>
@@ -66,7 +66,7 @@ export default function ProblemPanel({ onTransition }: ProblemPanelProps) {
               className="border-t border-gray-100 bg-gray-50"
             >
               <div className="p-3 space-y-2">
-                <div className="text-[11px] text-gray-400 uppercase tracking-wide px-1 mb-2">
+                <div className="text-label text-gray-400 uppercase tracking-wide px-1 mb-2">
                   Requires separate cycle for each language
                 </div>
                 {problemCards.map((card, index) => (
@@ -78,7 +78,7 @@ export default function ProblemPanel({ onTransition }: ProblemPanelProps) {
                     transition={{ duration: 0.25, delay: index * 0.1 }}
                   >
                     <div className="w-4 h-4 rounded border-2 border-gray-300 flex-shrink-0" />
-                    <span className="text-[14px] text-gray-700">
+                    <span className="text-body-sm text-gray-700">
                       {card.name} cycle
                     </span>
                   </motion.div>
@@ -93,7 +93,7 @@ export default function ProblemPanel({ onTransition }: ProblemPanelProps) {
       <AnimatePresence>
         {stage >= 2 && (
           <motion.div
-            className="text-[13px] text-gray-400 mt-4 mb-5"
+            className="text-caption text-gray-400 mt-4 mb-5"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ duration: 0.4 }}
@@ -108,7 +108,7 @@ export default function ProblemPanel({ onTransition }: ProblemPanelProps) {
         {stage >= 3 && (
           <motion.button
             onClick={onTransition}
-            className="w-full flex items-center justify-center gap-2 py-3 px-4 rounded-xl text-white font-medium text-[15px]"
+            className="w-full flex items-center justify-center gap-2 py-3 px-4 rounded-xl text-white font-medium text-body-sm"
             style={{ backgroundColor: '#0168b3' }}
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
@@ -117,7 +117,7 @@ export default function ProblemPanel({ onTransition }: ProblemPanelProps) {
             whileTap={{ scale: 0.98 }}
           >
             See the solution
-            <span className="material-icons-outlined text-[18px]">arrow_forward</span>
+            <span className="material-icons-outlined text-body">arrow_forward</span>
           </motion.button>
         )}
       </AnimatePresence>

--- a/src/components/vignettes/multilingual/TransitionPanel.tsx
+++ b/src/components/vignettes/multilingual/TransitionPanel.tsx
@@ -48,11 +48,11 @@ export default function TransitionPanel({ onComplete }: TransitionPanelProps) {
     <div className="w-full space-y-5">
       {/* Source question */}
       <div className="space-y-2">
-        <label className="text-[14px] font-semibold text-[#2f2438]">
+        <label className="text-body-sm font-semibold text-primary">
           {transitionContent.sourceLabel}
         </label>
         <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
-          <p className="text-[15px] text-gray-700">
+          <p className="text-body-sm text-gray-700">
             {transitionContent.sourceQuestion}
           </p>
         </div>
@@ -66,7 +66,7 @@ export default function TransitionPanel({ onComplete }: TransitionPanelProps) {
             className="flex items-start gap-4 p-3 bg-white border border-gray-200 rounded-lg"
           >
             <div className="flex-shrink-0 w-20">
-              <span className="text-[13px] font-medium text-gray-600">
+              <span className="text-caption font-medium text-gray-600">
                 {lang.name}
               </span>
             </div>
@@ -78,7 +78,7 @@ export default function TransitionPanel({ onComplete }: TransitionPanelProps) {
                     initial={{ opacity: 0, y: 4 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ duration: reducedMotion ? 0.15 : 0.4, ease: 'easeOut' }}
-                    className="text-[14px] text-gray-800"
+                    className="text-body-sm text-gray-800"
                     style={{ direction: lang.code === 'dv' ? 'rtl' : 'ltr' }}
                   >
                     {lang.translation}
@@ -93,7 +93,7 @@ export default function TransitionPanel({ onComplete }: TransitionPanelProps) {
                     transition={{ duration: 0.2 }}
                   />
                 ) : (
-                  <span className="text-[14px] text-gray-400 italic">
+                  <span className="text-body-sm text-gray-400 italic">
                     Translation will appear here
                   </span>
                 )}
@@ -112,13 +112,13 @@ export default function TransitionPanel({ onComplete }: TransitionPanelProps) {
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.3 }}
-            className="w-full flex items-center justify-center gap-2 py-3 px-4 rounded-xl text-white font-medium text-[15px]"
+            className="w-full flex items-center justify-center gap-2 py-3 px-4 rounded-xl text-white font-medium text-body-sm"
             style={{ backgroundColor: '#0168b3' }}
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
           >
             {transitionContent.continueLabel}
-            <span className="material-icons-outlined text-[18px]">arrow_forward</span>
+            <span className="material-icons-outlined text-body">arrow_forward</span>
           </motion.button>
         ) : (
           <motion.button
@@ -127,7 +127,7 @@ export default function TransitionPanel({ onComplete }: TransitionPanelProps) {
             disabled={state === 'translating'}
             initial={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            className="w-full flex items-center justify-center gap-2 py-3 px-4 rounded-xl text-white font-medium text-[15px] disabled:opacity-70 disabled:cursor-not-allowed"
+            className="w-full flex items-center justify-center gap-2 py-3 px-4 rounded-xl text-white font-medium text-body-sm disabled:opacity-70 disabled:cursor-not-allowed"
             style={{ backgroundColor: '#0168b3' }}
             whileHover={state === 'ready' ? { scale: 1.02 } : undefined}
             whileTap={state === 'ready' ? { scale: 0.98 } : undefined}
@@ -142,7 +142,7 @@ export default function TransitionPanel({ onComplete }: TransitionPanelProps) {
               </>
             ) : (
               <>
-                <span className="material-icons-outlined text-[18px]">bolt</span>
+                <span className="material-icons-outlined text-body">bolt</span>
                 {transitionContent.ctaLabel}
               </>
             )}

--- a/src/components/vignettes/multilingual/TranslationManagementPanel.tsx
+++ b/src/components/vignettes/multilingual/TranslationManagementPanel.tsx
@@ -64,14 +64,14 @@ export default function TranslationManagementPanel({
           style={getAnchorStyle('language-dropdown')}
           data-anchor="language-dropdown"
         >
-          <label className="text-[14px] font-semibold leading-[24px] text-[#2f2438]">
+          <label className="text-body-sm font-semibold text-primary">
             Translated language
           </label>
           <button
             onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-            className="bg-white border-2 border-[#878792] rounded-[6px] h-[36px] px-[10px] py-[6px] flex items-center justify-between gap-2 hover:border-[#0168b3] transition-colors"
+            className="bg-white border-2 border-[#878792] rounded-[6px] h-9 px-sm py-xs flex items-center justify-between gap-2 hover:border-[#0168b3] transition-colors"
           >
-            <span className="text-[14px] leading-[20px] text-[#2f2438] whitespace-nowrap">
+            <span className="text-body-sm text-primary whitespace-nowrap">
               {content.languages[selectedLanguage].name}
             </span>
             <svg className="w-4 h-4 text-[#2f2438] flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
@@ -99,7 +99,7 @@ export default function TranslationManagementPanel({
                         setTranslationState('idle');
                       }
                     }}
-                    className={`w-full px-[10px] py-[8px] text-left text-[14px] leading-[20px] text-[#2f2438] hover:bg-gray-50 transition-colors whitespace-nowrap ${
+                    className={`w-full px-sm py-sm text-left text-body-sm text-primary hover:bg-gray-50 transition-colors whitespace-nowrap ${
                       index === selectedLanguage ? 'bg-gray-100 font-semibold' : ''
                     } ${index === 0 ? 'rounded-t-[4px]' : ''} ${index === content.languages.length - 1 ? 'rounded-b-[4px]' : ''}`}
                   >
@@ -118,7 +118,7 @@ export default function TranslationManagementPanel({
             style={getAnchorStyle('auto-translate-btn')}
             data-anchor="auto-translate-btn"
             {...subtlePulse}
-            className="bg-[#0168b3] hover:bg-[#015a99] disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold text-[14px] leading-[20px] h-[36px] px-[14px] py-[8px] rounded-[6px] flex items-center gap-1.5 transition-colors"
+            className="bg-[#0168b3] hover:bg-[#015a99] disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold text-body-sm h-9 px-md py-sm rounded-[6px] flex items-center gap-1.5 transition-colors"
           >
             {translationState === 'translating' ? (
               <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
@@ -132,7 +132,7 @@ export default function TranslationManagementPanel({
             )}
             Auto translate
           </motion.button>
-          <button className="text-[#0168b3] hover:bg-gray-50 font-medium text-[14px] leading-[20px] h-[36px] px-[10px] py-[8px] rounded-[6px] flex items-center gap-1.5 transition-colors">
+          <button className="text-[#0168b3] hover:bg-gray-50 font-medium text-body-sm h-9 px-sm py-sm rounded-[6px] flex items-center gap-1.5 transition-colors">
             <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
               <path fillRule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clipRule="evenodd" />
             </svg>
@@ -144,7 +144,7 @@ export default function TranslationManagementPanel({
       <div className="space-y-6">
         {content.translationFields.map((field) => (
           <div key={field.id} className="space-y-3">
-            <label className="text-sm font-semibold text-[#2f2438]">
+            <label className="text-sm font-semibold text-primary">
               {field.label}
             </label>
 
@@ -183,10 +183,10 @@ export default function TranslationManagementPanel({
               style={getAnchorStyle('source-text')}
               data-anchor="source-text"
             >
-              <span className="inline-flex items-center px-3 py-1 bg-[#eaeaec] rounded-full text-xs text-[#2f2438]">
+              <span className="inline-flex items-center px-3 py-1 bg-[#eaeaec] rounded-full text-xs text-primary">
                 English (English US)
               </span>
-              <p className="text-sm text-[#6b7280]">
+              <p className="text-sm text-secondary">
                 {field.sourceText}
               </p>
             </div>

--- a/src/components/vignettes/prototyping/SandboxPanel.tsx
+++ b/src/components/vignettes/prototyping/SandboxPanel.tsx
@@ -62,7 +62,8 @@ function ProblemState({
       {/* CTA */}
       <motion.button
         onClick={onTransition}
-        className="mt-6 flex items-center justify-center gap-2 bg-[rgba(154,54,178,0.08)] hover:bg-[rgba(154,54,178,0.14)] px-5 py-3 rounded-full text-body-sm font-semibold transition-colors"
+        className="mt-6 flex items-center justify-center gap-2 px-5 py-3 rounded-full text-body-sm font-semibold transition-colors"
+        style={{ backgroundColor: 'var(--accent-interactive-bg)' }}
         initial={{ opacity: 0, y: 10 }}
         animate={{
           opacity: 1,
@@ -78,11 +79,11 @@ function ProblemState({
           y: { delay: 0.7, duration: 0.3 },
           boxShadow: { delay: 1.2, duration: 2.5, repeat: Infinity, ease: 'easeInOut' }
         }}
-        whileHover={{ scale: 1.02 }}
+        whileHover={{ scale: 1.02, backgroundColor: 'var(--accent-interactive-bg-hover)' }}
         whileTap={{ scale: 0.98 }}
       >
-        <span className="material-icons-outlined text-h3 text-[#9A36B2]">auto_awesome</span>
-        <span className="text-[#9A36B2]">See how I enabled this</span>
+        <span className="material-icons-outlined text-h3" style={{ color: 'var(--accent-interactive)' }}>auto_awesome</span>
+        <span style={{ color: 'var(--accent-interactive)' }}>See how I enabled this</span>
       </motion.button>
     </div>
   );

--- a/src/components/vignettes/prototyping/SandboxPanel.tsx
+++ b/src/components/vignettes/prototyping/SandboxPanel.tsx
@@ -36,7 +36,7 @@ function ProblemState({
           return (
             <motion.div
               key={q.id}
-              className="absolute bg-white px-4 py-2 rounded-lg shadow-sm border border-gray-200 text-[15px] text-gray-600 font-medium"
+              className="absolute bg-white px-4 py-2 rounded-lg shadow-sm border border-gray-200 text-body-sm text-gray-600 font-medium"
               style={{
                 ...pos,
                 transform: `rotate(${pos.rotate}deg)`,
@@ -62,7 +62,7 @@ function ProblemState({
       {/* CTA */}
       <motion.button
         onClick={onTransition}
-        className="mt-6 flex items-center justify-center gap-2 bg-[rgba(154,54,178,0.08)] hover:bg-[rgba(154,54,178,0.14)] px-5 py-3 rounded-full text-[14px] font-semibold transition-colors"
+        className="mt-6 flex items-center justify-center gap-2 bg-[rgba(154,54,178,0.08)] hover:bg-[rgba(154,54,178,0.14)] px-5 py-3 rounded-full text-body-sm font-semibold transition-colors"
         initial={{ opacity: 0, y: 10 }}
         animate={{
           opacity: 1,
@@ -81,7 +81,7 @@ function ProblemState({
         whileHover={{ scale: 1.02 }}
         whileTap={{ scale: 0.98 }}
       >
-        <span className="material-icons-outlined text-[20px] text-[#9A36B2]">auto_awesome</span>
+        <span className="material-icons-outlined text-h3 text-[#9A36B2]">auto_awesome</span>
         <span className="text-[#9A36B2]">See how I enabled this</span>
       </motion.button>
     </div>
@@ -105,7 +105,7 @@ function LoadingState() {
           <div className="w-3 h-3 rounded-full bg-yellow-500" />
           <div className="w-3 h-3 rounded-full bg-green-500" />
         </div>
-        <span className="text-[12px] text-gray-400 font-mono ml-2">Building sandbox infrastructure</span>
+        <span className="text-caption text-gray-400 font-mono ml-2">Building sandbox infrastructure</span>
       </div>
 
       {/* Setup steps */}
@@ -119,7 +119,7 @@ function LoadingState() {
             className="space-y-1"
           >
             {/* Command line */}
-            <div className="flex items-center gap-2 font-mono text-[12px]">
+            <div className="flex items-center gap-2 font-mono text-caption">
               <span className="text-gray-500">$</span>
               <span className="text-gray-400">{step.command}</span>
             </div>
@@ -135,7 +135,7 @@ function LoadingState() {
                   initial={{ scale: 0 }}
                   animate={{ scale: 1 }}
                   transition={{ delay: step.delay + 0.2, type: 'spring', stiffness: 500 }}
-                  className="text-green-400 text-[14px]"
+                  className="text-green-400 text-body-sm"
                 >
                   ✓
                 </motion.span>
@@ -143,12 +143,12 @@ function LoadingState() {
                 <motion.span
                   animate={{ rotate: 360 }}
                   transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
-                  className="text-blue-400 text-[14px]"
+                  className="text-blue-400 text-body-sm"
                 >
                   ⟳
                 </motion.span>
               )}
-              <span className={`text-[13px] ${index < setupSteps.length - 1 ? 'text-gray-500' : 'text-gray-300'}`}>
+              <span className={`text-caption ${index < setupSteps.length - 1 ? 'text-gray-500' : 'text-gray-300'}`}>
                 {step.label}
               </span>
             </motion.div>
@@ -165,12 +165,12 @@ function SolutionState({ content }: { content: PrototypingContent }) {
       {/* Main Sandbox Container */}
       <div className="bg-white border border-black rounded-lg p-4 w-full">
         {/* Header */}
-        <div className="flex items-center justify-between mb-[18px]">
+        <div className="flex items-center justify-between mb-lg">
           <div>
-            <h3 className="text-[16px] font-bold text-black font-[family-name:var(--font-inter)]">
+            <h3 className="text-body-sm font-bold text-black">
               {content.sandboxTitle}
             </h3>
-            <p className="text-[13px] text-gray-500 mt-0.5">
+            <p className="text-caption text-gray-500 mt-0.5">
               {content.adoptionStats.designers} designers • {content.adoptionStats.prototypes}+ prototypes
             </p>
           </div>
@@ -178,7 +178,7 @@ function SolutionState({ content }: { content: PrototypingContent }) {
         </div>
 
         {/* Prototype Grid */}
-        <div className="grid grid-cols-3 gap-[18px]">
+        <div className="grid grid-cols-3 gap-lg">
           {content.prototypes.map((item) => (
             <div
               key={item.id}
@@ -206,13 +206,13 @@ function SolutionState({ content }: { content: PrototypingContent }) {
               <div className="w-3 h-3 rounded-full bg-yellow-500" />
               <div className="w-3 h-3 rounded-full bg-green-500" />
             </div>
-            <span className="text-[12px] text-gray-400 font-mono ml-2">claude-code</span>
+            <span className="text-caption text-gray-400 font-mono ml-2">claude-code</span>
           </div>
-          <span className="text-[10px] text-gray-500 font-mono">~/.../sandbox</span>
+          <span className="text-label text-gray-500 font-mono">~/.../sandbox</span>
         </div>
 
         {/* TUI Content */}
-        <div className="p-4 font-mono text-[13px] leading-relaxed">
+        <div className="p-4 font-mono text-caption leading-relaxed">
           {/* Command prompt */}
           <div className="flex items-start gap-2 mb-3">
             <span className="text-blue-400 select-none">❯</span>

--- a/src/components/vignettes/shared/DesignNotesButton.tsx
+++ b/src/components/vignettes/shared/DesignNotesButton.tsx
@@ -14,7 +14,7 @@ export default function DesignNotesButton({
   return (
     <button
       onClick={onToggle}
-      className="inline-flex items-center gap-2 text-[14px] font-medium text-[#0f172a] px-3 py-2 rounded-lg border border-gray-200 hover:border-gray-300 transition-colors"
+      className="inline-flex items-center gap-2 text-body-sm font-medium text-primary px-3 py-2 rounded-lg border border-gray-200 hover:border-gray-300 transition-colors"
       style={{
         backgroundColor: isActive ? `${DESIGN_NOTES_ACCENT}12` : 'white',
         borderColor: isActive ? `${DESIGN_NOTES_ACCENT}50` : undefined,
@@ -22,8 +22,8 @@ export default function DesignNotesButton({
       }}
     >
       <span
-        className="material-icons-outlined text-[18px]"
-        style={{ color: isActive ? DESIGN_NOTES_ACCENT : '#0f172a' }}
+        className="material-icons-outlined text-body"
+        style={{ color: isActive ? DESIGN_NOTES_ACCENT : undefined }}
       >
         {isActive ? 'close' : 'edit'}
       </span>

--- a/src/components/vignettes/shared/RedlineOverlay.tsx
+++ b/src/components/vignettes/shared/RedlineOverlay.tsx
@@ -96,10 +96,10 @@ export default function RedlineOverlay({
                           : '0 12px 40px rgba(248, 113, 113, 0.15)',
                       }}
                     >
-                      <p className="text-[13px] font-semibold leading-[1.3]" style={{ color: accent }}>
+                      <p className="text-caption font-semibold leading-snug" style={{ color: accent }}>
                         {note.label}
                       </p>
-                      <p className="text-[13px] leading-[1.5] mt-1 text-[#475569]">
+                      <p className="text-caption leading-normal mt-1 text-secondary">
                         {note.detail}
                       </p>
                     </motion.div>

--- a/src/components/vignettes/shared/StageIndicator.tsx
+++ b/src/components/vignettes/shared/StageIndicator.tsx
@@ -9,7 +9,7 @@ interface StageIndicatorProps {
 
 export default function StageIndicator({ stage, onStageChange }: StageIndicatorProps) {
   return (
-    <div className="flex items-center gap-1.5 text-[13px] text-gray-400 select-none">
+    <div className="flex items-center gap-1.5 text-caption text-gray-400 select-none">
       <button
         onClick={() => onStageChange('problem')}
         className={`hover:text-gray-500 transition-colors ${stage === 'problem' ? 'text-gray-600' : ''}`}

--- a/src/components/vignettes/shared/design-notes.css
+++ b/src/components/vignettes/shared/design-notes.css
@@ -120,7 +120,7 @@
   border-radius: 50%;
   background: var(--accent, #ef4444);
   color: white;
-  font-size: 12px;
+  font-size: 0.8125rem; /* caption size */
   font-weight: 600;
   display: flex;
   align-items: center;

--- a/src/components/vignettes/vibe-coding/DemoCreationFlow.tsx
+++ b/src/components/vignettes/vibe-coding/DemoCreationFlow.tsx
@@ -128,9 +128,13 @@ export default function DemoCreationFlow({ onComplete }: DemoCreationFlowProps) 
                 <div className="flex items-center justify-center h-full">
                   <button
                     onClick={startDemo}
-                    className="px-6 py-3 bg-neutral-900 hover:bg-neutral-800 text-white text-sm font-medium rounded-lg transition-colors"
+                    className="px-6 py-3 text-sm font-semibold rounded-full transition-colors flex items-center gap-2"
+                    style={{ backgroundColor: 'var(--accent-interactive-bg)' }}
+                    onMouseEnter={(e) => e.currentTarget.style.backgroundColor = 'var(--accent-interactive-bg-hover)'}
+                    onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'var(--accent-interactive-bg)'}
                   >
-                    ▶ Start Demo
+                    <span className="material-icons-outlined text-lg" style={{ color: 'var(--accent-interactive)' }}>play_arrow</span>
+                    <span style={{ color: 'var(--accent-interactive)' }}>Start Demo</span>
                   </button>
                 </div>
               )}
@@ -251,11 +255,12 @@ export default function DemoCreationFlow({ onComplete }: DemoCreationFlowProps) 
         <div className="mt-6 text-center">
           <button
             onClick={startDemo}
-            className="px-4 py-2 bg-transparent hover:bg-neutral-100 text-neutral-600 hover:text-neutral-900 text-sm font-medium rounded-lg transition-all duration-200 flex items-center space-x-2 mx-auto border border-neutral-200"
+            className="px-4 py-2 text-sm font-medium rounded-full transition-colors flex items-center gap-2 mx-auto"
+            style={{ backgroundColor: 'var(--accent-interactive-bg)', color: 'var(--accent-interactive)' }}
+            onMouseEnter={(e) => e.currentTarget.style.backgroundColor = 'var(--accent-interactive-bg-hover)'}
+            onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'var(--accent-interactive-bg)'}
           >
-            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-            </svg>
+            <span className="material-icons-outlined text-base">replay</span>
             <span>Replay</span>
           </button>
         </div>

--- a/src/components/vignettes/vibe-coding/VibeCodingVignette.tsx
+++ b/src/components/vignettes/vibe-coding/VibeCodingVignette.tsx
@@ -26,12 +26,16 @@ export default function VibeCodingVignette() {
                 href="https://studio.up.railway.app/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 px-4 py-2.5 bg-[#1a1d23] text-white hover:bg-[#2a2d33] transition-colors font-medium rounded-lg text-body-sm"
+                className="inline-flex items-center gap-2 px-4 py-2.5 rounded-full font-semibold text-body-sm transition-colors"
+                style={{
+                  backgroundColor: 'var(--accent-interactive-bg)',
+                  color: 'var(--accent-interactive)'
+                }}
+                onMouseEnter={(e) => e.currentTarget.style.backgroundColor = 'var(--accent-interactive-bg-hover)'}
+                onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'var(--accent-interactive-bg)'}
               >
                 Join the waitlist
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
-                </svg>
+                <span className="material-icons-outlined text-base">arrow_forward</span>
               </a>
             )}
           >

--- a/src/components/vignettes/vibe-coding/VibeCodingVignette.tsx
+++ b/src/components/vignettes/vibe-coding/VibeCodingVignette.tsx
@@ -26,7 +26,7 @@ export default function VibeCodingVignette() {
                 href="https://studio.up.railway.app/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 px-4 py-2.5 bg-[#1a1d23] text-white hover:bg-[#2a2d33] transition-colors font-medium rounded-lg text-[15px] leading-[1.4]"
+                className="inline-flex items-center gap-2 px-4 py-2.5 bg-[#1a1d23] text-white hover:bg-[#2a2d33] transition-colors font-medium rounded-lg text-body-sm"
               >
                 Join the waitlist
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/thoughts/shared/plans/2025-12-26-font-color-cleanup.md
+++ b/thoughts/shared/plans/2025-12-26-font-color-cleanup.md
@@ -1,0 +1,283 @@
+# Font & Color System Cleanup Implementation Plan
+
+## Overview
+
+Clean up unused fonts and refine the color system based on typeface research. This simplifies the codebase to a single loaded font (Inter) with system mono fallback, and establishes a flexible Zinc-based neutral palette with an accent slot ready for future personality.
+
+## Current State Analysis
+
+### Fonts Currently Loaded (4 fonts)
+| Font | Variable | Status |
+|------|----------|--------|
+| Inter | `--font-inter` | USED - primary sans |
+| Geist Mono | `--font-geist-mono` | Used in 5 places (SandboxPanel) |
+| Geist Sans | `--font-geist-sans` | NOT USED |
+| IBM Plex Sans | `--font-ibm-plex-sans` | NOT USED |
+
+### Current Colors
+```css
+--background: #fefefe;
+--foreground: #1a1d23;
+--primary: #1a1d23;
+--secondary: #6b7280;
+--tertiary: #9ca3af;
+--muted: #f8f9fa;
+--border: #e5e7eb;
+--accent: #2563eb;
+```
+
+## Desired End State
+
+### Fonts (1 loaded font + system mono)
+- **Inter**: Only loaded font (400, 600 weights)
+- **System mono stack**: `ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace`
+
+### Colors (Zinc-based neutrals + flexible accent)
+```css
+/* Full neutral scale for flexibility */
+--neutral-50: #fafafa;
+--neutral-100: #f4f4f5;
+--neutral-200: #e4e4e7;
+--neutral-300: #d4d4d8;
+--neutral-400: #a1a1aa;
+--neutral-500: #71717a;
+--neutral-600: #52525b;
+--neutral-700: #3f3f46;
+--neutral-800: #27272a;
+--neutral-900: #18181b;
+--neutral-950: #09090b;
+
+/* Semantic mapping */
+--background: var(--neutral-50);   /* was #fefefe */
+--foreground: var(--neutral-900);  /* was #1a1d23 */
+--primary: var(--neutral-900);
+--secondary: var(--neutral-600);   /* was #6b7280 */
+--tertiary: var(--neutral-400);    /* was #9ca3af */
+--muted: var(--neutral-100);       /* was #f8f9fa */
+--border: var(--neutral-200);      /* was #e5e7eb */
+
+/* Accent - ready for future personality */
+--accent: #2563eb;                 /* keeping blue for now */
+```
+
+## What We're NOT Doing
+
+- Not changing typography tokens (already migrated)
+- Not touching component logic
+- Not adding dark mode
+- Not changing the accent color yet (that's for later experimentation)
+
+---
+
+## Phase 1: Font Cleanup
+
+### Overview
+Remove unused font imports and switch to system mono stack.
+
+### Changes Required:
+
+#### 1. Update layout.tsx
+**File**: `src/app/layout.tsx`
+
+**Remove imports and configurations:**
+```diff
+- import { Geist, Geist_Mono, IBM_Plex_Sans, Inter } from "next/font/google";
++ import { Inter } from "next/font/google";
+
+- const geistSans = Geist({
+-   variable: "--font-geist-sans",
+-   subsets: ["latin"],
+- });
+-
+- const geistMono = Geist_Mono({
+-   variable: "--font-geist-mono",
+-   subsets: ["latin"],
+- });
+-
+- const ibmPlexSans = IBM_Plex_Sans({
+-   variable: "--font-ibm-plex-sans",
+-   subsets: ["latin"],
+-   weight: ["400", "500", "600"],
+- });
+-
+  const inter = Inter({
+    variable: "--font-inter",
+    subsets: ["latin"],
+-   weight: ["400", "600"],
++   weight: ["400", "500", "600"],
+  });
+```
+
+**Update body className:**
+```diff
+- className={`${geistSans.variable} ${geistMono.variable} ${ibmPlexSans.variable} ${inter.variable} antialiased`}
++ className={`${inter.variable} antialiased`}
+```
+
+#### 2. Update globals.css font reference
+**File**: `src/app/globals.css`
+
+**Change mono font to system stack:**
+```diff
+  /* Fonts - switch to Inter */
+  --font-sans: var(--font-inter);
+- --font-mono: var(--font-geist-mono);
++ --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+```
+
+#### 3. Remove redundant font overrides
+**File**: `src/components/vignettes/ai-highlights/HighlightsPanel.tsx`
+
+Find and remove `font-[family-name:var(--font-inter)]` from className (line ~290).
+
+**File**: `src/components/vignettes/ai-suggestions/SuggestionsPanel.tsx`
+
+Find and remove `font-[family-name:var(--font-inter)]` from className (line ~184).
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Build succeeds: `npm run build`
+- [x] No references to removed fonts: `grep -r "geist-sans\|ibm-plex" src/`
+- [x] No references to Geist_Mono import: `grep -r "Geist_Mono" src/`
+
+#### Manual Verification:
+- [x] Homepage renders correctly
+- [x] Terminal text in Prototyping vignette still looks appropriate with system mono
+- [x] No visual regressions in vignette panels
+
+---
+
+## Phase 2: Color System Refinement
+
+### Overview
+Establish Zinc-based neutral scale with semantic mapping, keeping accent flexible for future.
+
+### Changes Required:
+
+#### 1. Update globals.css color variables
+**File**: `src/app/globals.css`
+
+**Replace the `:root` color block with:**
+```css
+:root {
+  /* Neutral scale (Zinc-based, slightly warm) */
+  --neutral-50: #fafafa;
+  --neutral-100: #f4f4f5;
+  --neutral-200: #e4e4e7;
+  --neutral-300: #d4d4d8;
+  --neutral-400: #a1a1aa;
+  --neutral-500: #71717a;
+  --neutral-600: #52525b;
+  --neutral-700: #3f3f46;
+  --neutral-800: #27272a;
+  --neutral-900: #18181b;
+  --neutral-950: #09090b;
+
+  /* Semantic color mapping */
+  --background: var(--neutral-50);
+  --foreground: var(--neutral-900);
+  --muted: var(--neutral-100);
+  --muted-foreground: var(--neutral-600);
+  --muted-tertiary: var(--neutral-400);
+  --border: var(--neutral-200);
+
+  /* Accent - swap this for personality later */
+  --accent: #2563eb;
+  --accent-foreground: #ffffff;
+  --warm-accent: #f59e0b;
+
+  /* Semantic text colors */
+  --primary: var(--neutral-900);
+  --secondary: var(--neutral-600);
+  --tertiary: var(--neutral-400);
+
+  /* Status colors */
+  --success: #059669;
+  --warning: #f59e0b;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+
+  /* Border radius */
+  --radius-sm: 0.375rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+}
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Build succeeds: `npm run build`
+- [x] TypeScript passes: `npx tsc --noEmit`
+
+#### Manual Verification:
+- [x] Background has subtle warm tint (not pure white)
+- [x] Text hierarchy is clear (primary darker than secondary)
+- [x] Borders are visible but subtle
+- [x] Accent color (blue) still works for links/focus states
+- [ ] All vignettes render correctly
+
+---
+
+## Phase 3: Final Verification
+
+### Automated Checks
+```bash
+# Build must succeed
+npm run build
+
+# No hardcoded font references to removed fonts
+grep -rE "geist-sans|ibm-plex|Geist_Mono|IBM_Plex" src/
+
+# Should return empty (all font variables cleaned up)
+```
+
+### Manual Testing Checklist
+1. [ ] Open http://localhost:3000
+2. [ ] Hero text renders in Inter
+3. [ ] Scroll through all vignettes - no visual regressions
+4. [ ] Prototyping vignette terminal text uses system mono (should look similar)
+5. [ ] Color palette feels slightly warmer but still professional
+6. [ ] Check mobile layout
+
+---
+
+## Performance Impact
+
+**Font loading reduction:**
+- Before: 4 font families (Inter, Geist Sans, Geist Mono, IBM Plex Sans)
+- After: 1 font family (Inter with 3 weights)
+
+**Expected improvement:**
+- Fewer HTTP requests
+- Smaller initial bundle
+- Faster First Contentful Paint
+
+---
+
+## Future: Fun Color System
+
+The neutral scale is now in place. To add personality later:
+
+1. **Change accent color**: Simply update `--accent: #2563eb` to any color
+2. **Add gradient accents**: Create `--accent-gradient` variable
+3. **Seasonal themes**: Swap accent programmatically
+4. **Multiple accent palette**: Add `--accent-secondary`, `--accent-tertiary`
+
+Example fun palettes to try later:
+- Coral: `--accent: #f97316`
+- Electric purple: `--accent: #8b5cf6`
+- Teal: `--accent: #14b8a6`
+- Anthropic rust: `--accent: #c2410c`
+
+---
+
+## References
+
+- Typeface research: `thoughts/shared/research/2025-12-26-portfolio-typeface-selection.md`
+- Font cleanup research: `thoughts/shared/research/2025-12-26-font-typeface-cleanup.md`
+- Typography migration: `thoughts/shared/plans/2025-12-26-typography-spacing-scale-migration.md`

--- a/thoughts/shared/plans/2025-12-26-typography-spacing-scale-migration.md
+++ b/thoughts/shared/plans/2025-12-26-typography-spacing-scale-migration.md
@@ -1,0 +1,529 @@
+# Typography & Spacing Scale Migration
+
+## Overview
+
+Replace 80+ hardcoded typography values and 24+ hardcoded spacing values with a semantic, Tailwind v4-integrated design system.
+
+## Progress Tracking
+
+### Phase 1: Foundation (must complete first)
+- [ ] **TASK-01**: Update `globals.css` with tokens and composed classes
+
+### Phase 2: Component Migrations (parallelizable after Phase 1)
+- [ ] **TASK-02**: `src/app/page.tsx`
+- [ ] **TASK-03**: `src/components/SectionHeader.tsx`
+- [ ] **TASK-04**: `src/components/vignettes/VignetteSplit.tsx`
+- [ ] **TASK-05**: `src/components/vignettes/VignetteStaged.tsx`
+- [ ] **TASK-06**: `src/components/vignettes/VignetteContainer.tsx`
+- [ ] **TASK-07**: `src/components/vignettes/ai-highlights/HighlightsPanel.tsx`
+- [ ] **TASK-08**: `src/components/vignettes/ai-suggestions/SuggestionsPanel.tsx`
+- [ ] **TASK-09**: `src/components/vignettes/home-connect/HomeConnectPanel.tsx`
+- [ ] **TASK-10**: `src/components/vignettes/home-connect/ProblemPanel.tsx`
+- [ ] **TASK-11**: `src/components/vignettes/home-connect/TransitionPanel.tsx`
+- [ ] **TASK-12**: `src/components/vignettes/multilingual/ProblemPanel.tsx`
+- [ ] **TASK-13**: `src/components/vignettes/multilingual/TransitionPanel.tsx`
+- [ ] **TASK-14**: `src/components/vignettes/multilingual/TranslationManagementPanel.tsx`
+- [ ] **TASK-15**: `src/components/vignettes/prototyping/SandboxPanel.tsx`
+- [ ] **TASK-16**: `src/components/vignettes/vibe-coding/VibeCodingVignette.tsx`
+- [ ] **TASK-17**: `src/components/vignettes/shared/DesignNotesButton.tsx`
+- [ ] **TASK-18**: `src/components/vignettes/shared/RedlineOverlay.tsx`
+- [ ] **TASK-19**: `src/components/vignettes/shared/StageIndicator.tsx`
+- [ ] **TASK-20**: `src/components/demos/RichTextEditor.tsx`
+
+### Phase 3: Cleanup (after all Phase 2 tasks)
+- [ ] **TASK-21**: Remove old CSS variables from `globals.css`
+- [ ] **TASK-22**: Update `design-notes.css`
+- [ ] **TASK-23**: Final verification
+
+---
+
+## How Agents Should Use This Plan
+
+1. Read this file to find uncompleted tasks (`[ ]`)
+2. Pick any uncompleted task from current phase
+3. Read the task definition below for exact changes
+4. Make the changes
+5. Mark task complete: change `[ ]` to `[x]` in Progress Tracking
+6. Add notes if any issues encountered
+7. Clear context and pick next task
+
+**Token Reference** (memorize or copy):
+| Composed Class | Use For |
+|----------------|---------|
+| `type-display` | Hero heading only |
+| `type-h2` | Section titles, vignette titles |
+| `type-body` | Descriptions, paragraphs |
+| `type-body-sm` | UI text, buttons, smaller body |
+| `type-caption` | Metadata, timestamps (13px) |
+| `type-label` | Badges, micro text (11px) |
+
+**Color Reference**:
+| Old | New |
+|-----|-----|
+| `text-[#0f172a]` | `text-primary` |
+| `text-[#4b5563]` | `text-secondary` |
+| `text-[#6b7280]` | `text-secondary` |
+| `text-[#9ca3af]` | `text-tertiary` |
+
+---
+
+## Task Definitions
+
+---
+
+### TASK-01: Update globals.css
+
+**File**: `src/app/globals.css`
+**Status**: Foundation task - must complete before all others
+
+**Changes**:
+
+1. Replace `@theme inline` block (lines 57-74) with:
+
+```css
+@theme inline {
+  /* Colors (existing) */
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-muted-tertiary: var(--muted-tertiary);
+  --color-border: var(--border);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-warm-accent: var(--warm-accent);
+  --color-primary: var(--primary);
+  --color-secondary: var(--secondary);
+  --color-tertiary: var(--tertiary);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
+
+  /* Fonts - switch to Inter */
+  --font-sans: var(--font-inter);
+  --font-mono: var(--font-geist-mono);
+
+  /* Typography - font sizes */
+  --font-size-display: clamp(2.75rem, 8vw, 4.5rem);
+  --font-size-h2: 1.625rem;
+  --font-size-h3: 1.125rem;
+  --font-size-body: 1.125rem;
+  --font-size-body-sm: 0.9375rem;
+  --font-size-caption: 0.8125rem;
+  --font-size-label: 0.6875rem;
+
+  /* Typography - line heights */
+  --line-height-display: 0.95;
+  --line-height-tight: 1.15;
+  --line-height-snug: 1.3;
+  --line-height-normal: 1.5;
+  --line-height-relaxed: 1.65;
+
+  /* Typography - letter spacing */
+  --letter-spacing-tighter: -0.04em;
+  --letter-spacing-tight: -0.02em;
+  --letter-spacing-normal: 0;
+  --letter-spacing-wide: 0.02em;
+
+  /* Spacing */
+  --spacing-2xs: 0.125rem;
+  --spacing-xs: 0.25rem;
+  --spacing-sm: 0.5rem;
+  --spacing-md: 1rem;
+  --spacing-lg: 1.5rem;
+  --spacing-xl: 2rem;
+  --spacing-2xl: 3rem;
+  --spacing-3xl: 4rem;
+  --spacing-4xl: 6rem;
+}
+```
+
+2. Add composed typography classes after `@theme inline` block:
+
+```css
+/* Composed typography classes */
+.type-display {
+  @apply text-display leading-display tracking-tighter font-bold text-primary;
+}
+
+.type-h2 {
+  @apply text-h2 leading-tight tracking-tight font-semibold text-primary;
+}
+
+.type-h3 {
+  @apply text-h3 leading-snug font-semibold text-primary;
+}
+
+.type-body {
+  @apply text-body leading-relaxed text-secondary;
+}
+
+.type-body-sm {
+  @apply text-body-sm leading-normal text-secondary;
+}
+
+.type-caption {
+  @apply text-caption leading-normal text-tertiary;
+}
+
+.type-label {
+  @apply text-label leading-normal tracking-wide text-tertiary;
+}
+```
+
+**Verify**: Run `npm run build` - must succeed before other tasks can start.
+
+---
+
+### TASK-02: page.tsx
+
+**File**: `src/app/page.tsx`
+
+**Find and replace**:
+
+| Line | Before | After |
+|------|--------|-------|
+| 12 | `text-[#0f172a]` | `text-primary` |
+| 18 | `className="text-[clamp(44px,8vw,72px)] leading-[0.95] tracking-[-0.04em] font-bold text-[#0f172a]"` | `className="type-display"` |
+| 21 | `className="text-[clamp(18px,3vw,22px)] leading-[1.6] text-[#4b5563] max-w-2xl"` | `className="type-body max-w-2xl"` |
+| 30 | `className="text-[18px] leading-[1.7] text-[#4b5563] font-[family-name:var(--font-ibm-plex-sans)] max-w-3xl"` | `className="type-body max-w-3xl"` |
+| 33 | `className="text-[18px] leading-[1.7] text-[#4b5563] font-[family-name:var(--font-ibm-plex-sans)] max-w-3xl"` | `className="type-body max-w-3xl"` |
+| 53 | `className="text-[18px] leading-[1.7] text-[#4b5563] font-[family-name:var(--font-ibm-plex-sans)] max-w-3xl"` | `className="type-body max-w-3xl"` |
+
+---
+
+### TASK-03: SectionHeader.tsx
+
+**File**: `src/components/SectionHeader.tsx`
+
+**Find and replace**:
+
+| Line | Before | After |
+|------|--------|-------|
+| 12 | `className="text-[24px] lg:text-[26px] leading-[1.2] tracking-[-0.02em] font-semibold text-[#0f172a]"` | `className="type-h2"` |
+
+---
+
+### TASK-04: VignetteSplit.tsx
+
+**File**: `src/components/vignettes/VignetteSplit.tsx`
+
+**Find and replace**:
+
+| Line | Before | After |
+|------|--------|-------|
+| 25 | `className="text-[26px] lg:text-[28px] leading-[1.15] tracking-[-0.02em] font-semibold text-[#0f172a] font-[family-name:var(--font-ibm-plex-sans)]"` | `className="type-h2"` |
+| 30 | `className="text-[18px] leading-[1.6] text-[#4b5563] font-[family-name:var(--font-ibm-plex-sans)] max-w-xl"` | `className="type-body max-w-xl"` |
+
+---
+
+### TASK-05: VignetteStaged.tsx
+
+**File**: `src/components/vignettes/VignetteStaged.tsx`
+
+**Find and replace**:
+
+| Line | Before | After |
+|------|--------|-------|
+| 62 | `className="text-[26px] lg:text-[28px] leading-[1.15] tracking-[-0.02em] font-semibold text-[#0f172a] font-[family-name:var(--font-ibm-plex-sans)]"` | `className="type-h2"` |
+| 66 | `className="text-[18px] leading-[1.6] text-[#4b5563] font-[family-name:var(--font-ibm-plex-sans)] max-w-xl"` | `className="type-body max-w-xl"` |
+| 78 | `className="flex items-center gap-2 text-[16px] text-[#4b5563] hover:text-[#0f172a] transition-colors font-[family-name:var(--font-ibm-plex-sans)]"` | `className="flex items-center gap-2 type-body-sm hover:text-primary transition-colors"` |
+| 82 | `text-[20px]` | `text-h3` |
+| 110 | `className="flex items-center gap-2 text-[16px] text-[#4b5563] hover:text-[#0f172a] transition-colors font-[family-name:var(--font-ibm-plex-sans)] group"` | `className="flex items-center gap-2 type-body-sm hover:text-primary transition-colors group"` |
+| 112 | `text-[20px]` | `text-h3` |
+| 115 | `text-[18px]` | `text-body` |
+
+---
+
+### TASK-06: VignetteContainer.tsx
+
+**File**: `src/components/vignettes/VignetteContainer.tsx`
+
+**Find and replace**:
+
+| Line | Before | After |
+|------|--------|-------|
+| 34 | `className="text-[24px] lg:text-[26px] leading-[1.2] tracking-[-0.02em] font-semibold text-[#0f172a]"` | `className="type-h2"` |
+| 38 | `className="text-[16px] leading-[1.6] text-gray-600"` | `className="type-body-sm"` |
+
+---
+
+### TASK-07: HighlightsPanel.tsx
+
+**File**: `src/components/vignettes/ai-highlights/HighlightsPanel.tsx`
+
+**Token mapping for this file**:
+- `text-[20px]` → `type-h3` or `text-h3`
+- `text-[18px]` → `type-body` or `text-body`
+- `text-[16px]` → `type-body-sm` or `text-body-sm`
+- `text-[14px]`, `text-[15px]` → `text-body-sm`
+- `text-[13px]`, `text-[12px]` → `text-caption`
+- `text-[#2f2438]` → `text-primary`
+- `text-[#524e56]` → `text-secondary`
+- `leading-[16px]`, `leading-[18px]`, `leading-[20px]`, `leading-[24px]`, `leading-[30px]` → `leading-normal` or `leading-snug`
+
+**Note**: This file has 40+ instances. Replace systematically. Keep `p-[2px]` for gradient borders.
+
+---
+
+### TASK-08: SuggestionsPanel.tsx
+
+**File**: `src/components/vignettes/ai-suggestions/SuggestionsPanel.tsx`
+
+**Token mapping**:
+- `text-[20px]` → `text-h3`
+- `text-[16px]` → `text-body-sm`
+- `text-[#2f2438]` → `text-primary`
+- `text-[#524e56]` → `text-secondary`
+- Keep `p-[2px]` for gradient borders
+
+---
+
+### TASK-09: HomeConnectPanel.tsx
+
+**File**: `src/components/vignettes/home-connect/HomeConnectPanel.tsx`
+
+**Token mapping**:
+- `text-[22px]` → `text-h3`
+- `text-[16px]` → `text-body-sm`
+- `text-[15px]` → `text-body-sm`
+- `text-[13px]` → `text-caption`
+- `text-[12px]` → `text-caption`
+- `text-[11px]` → `text-label`
+- `text-[#2F2438]` → `text-primary`
+
+**Note**: Keep dynamic `fontSize: size * 0.45` as-is (line 18).
+
+---
+
+### TASK-10: home-connect/ProblemPanel.tsx
+
+**File**: `src/components/vignettes/home-connect/ProblemPanel.tsx`
+
+**Token mapping**:
+- `text-[18px]` → `text-body`
+- `text-[15px]` → `text-body-sm`
+- `text-[12px]` → `text-caption`
+- `text-[11px]` → `text-label`
+- `text-[#2F2438]` → `text-primary`
+
+---
+
+### TASK-11: home-connect/TransitionPanel.tsx
+
+**File**: `src/components/vignettes/home-connect/TransitionPanel.tsx`
+
+**Token mapping**:
+- `text-[22px]` → `text-h3`
+- `text-[15px]` → `text-body-sm`
+- `text-[12px]` → `text-caption`
+- `text-[11px]` → `text-label`
+
+---
+
+### TASK-12: multilingual/ProblemPanel.tsx
+
+**File**: `src/components/vignettes/multilingual/ProblemPanel.tsx`
+
+**Token mapping**:
+- `text-[20px]` → `text-h3`
+- `text-[18px]` → `text-body`
+- `text-[15px]` → `text-body-sm`
+- `text-[14px]` → `text-body-sm`
+- `text-[13px]` → `text-caption`
+- `text-[12px]` → `text-caption`
+- `text-[11px]` → `text-label`
+
+---
+
+### TASK-13: multilingual/TransitionPanel.tsx
+
+**File**: `src/components/vignettes/multilingual/TransitionPanel.tsx`
+
+**Token mapping**:
+- `text-[18px]` → `text-body`
+- `text-[15px]` → `text-body-sm`
+- `text-[14px]` → `text-body-sm`
+- `text-[13px]` → `text-caption`
+
+---
+
+### TASK-14: multilingual/TranslationManagementPanel.tsx
+
+**File**: `src/components/vignettes/multilingual/TranslationManagementPanel.tsx`
+
+**Token mapping**:
+- `text-[14px]` → `text-body-sm`
+- `text-[#2f2438]` → `text-primary`
+- `text-[#6b7280]` → `text-secondary`
+- `leading-[20px]`, `leading-[24px]` → `leading-normal`
+
+**Spacing**:
+- `px-[10px]` → `px-sm`
+- `py-[6px]` → keep as-is or `py-xs`
+- `py-[8px]` → `py-sm`
+- `px-[14px]` → `px-md`
+- `h-[36px]` → `h-9`
+
+---
+
+### TASK-15: prototyping/SandboxPanel.tsx
+
+**File**: `src/components/vignettes/prototyping/SandboxPanel.tsx`
+
+**Token mapping**:
+- `text-[20px]` → `text-h3`
+- `text-[16px]` → `text-body-sm`
+- `text-[15px]` → `text-body-sm`
+- `text-[14px]` → `text-body-sm`
+- `text-[13px]` → `text-caption`
+- `text-[12px]` → `text-caption`
+- `text-[10px]` → `text-label`
+
+**Spacing**:
+- `mb-[18px]` → `mb-lg`
+- `gap-[18px]` → `gap-lg`
+
+---
+
+### TASK-16: vibe-coding/VibeCodingVignette.tsx
+
+**File**: `src/components/vignettes/vibe-coding/VibeCodingVignette.tsx`
+
+**Token mapping**:
+- `text-[15px]` → `text-body-sm`
+- `leading-[1.4]` → `leading-normal`
+
+---
+
+### TASK-17: shared/DesignNotesButton.tsx
+
+**File**: `src/components/vignettes/shared/DesignNotesButton.tsx`
+
+**Token mapping**:
+- `text-[14px]` → `text-body-sm`
+- `text-[18px]` → `text-body`
+- `text-[#0f172a]` → `text-primary`
+
+---
+
+### TASK-18: shared/RedlineOverlay.tsx
+
+**File**: `src/components/vignettes/shared/RedlineOverlay.tsx`
+
+**Token mapping**:
+- `text-[13px]` → `text-caption`
+- `leading-[1.3]` → `leading-snug`
+- `leading-[1.5]` → `leading-normal`
+- `text-[#475569]` → `text-secondary`
+
+---
+
+### TASK-19: shared/StageIndicator.tsx
+
+**File**: `src/components/vignettes/shared/StageIndicator.tsx`
+
+**Token mapping**:
+- `text-[13px]` → `text-caption`
+
+---
+
+### TASK-20: demos/RichTextEditor.tsx
+
+**File**: `src/components/demos/RichTextEditor.tsx`
+
+**Token mapping**:
+- `text-[20px]` → `text-h3`
+- `text-[#2f2438]` → `text-primary`
+- `text-[rgba(47,36,56,0.7)]` → `text-secondary`
+
+---
+
+### TASK-21: Remove old CSS variables
+
+**File**: `src/app/globals.css`
+
+**Delete** these variable definitions from `:root` (lines 22-44):
+- `--space-xs`, `--space-sm`, `--space-md`, `--space-lg`, `--space-xl`, `--space-2xl`, `--space-3xl`
+- `--text-xs`, `--text-sm`, `--text-base`, `--text-lg`, `--text-xl`, `--text-2xl`, `--text-3xl`, `--text-4xl`
+- `--leading-tight`, `--leading-normal`, `--leading-relaxed`
+
+**Keep** these (still used):
+- All color variables
+- Shadow variables
+- Border radius variables
+
+---
+
+### TASK-22: Update design-notes.css
+
+**File**: `src/components/vignettes/shared/design-notes.css`
+
+**Find and replace**:
+
+| Line | Before | After |
+|------|--------|-------|
+| 123 | `font-size: 12px;` | `font-size: var(--font-size-caption);` |
+
+---
+
+### TASK-23: Final verification
+
+**Run these commands**:
+
+```bash
+# Build must succeed
+npm run build
+
+# Should return 0 results (excluding color hex values)
+grep -rE "text-\[[0-9]" src/ | grep -v "text-\[#"
+
+# Should return 0 results
+grep -rE "(p|m|gap)-\[[0-9]" src/
+```
+
+**Manual checks**:
+1. Open http://localhost:3000
+2. Verify hero renders correctly
+3. Scroll through all vignettes
+4. Click through Problem → Solution → Design Notes on each
+5. Check mobile layout
+
+---
+
+## Reference: Token Definitions
+
+### Typography Scale
+
+| Token | Size | Use |
+|-------|------|-----|
+| `display` | clamp(44px, 8vw, 72px) | Hero only |
+| `h2` | 26px (1.625rem) | Section titles |
+| `h3` | 18px (1.125rem) | Subheadings |
+| `body` | 18px (1.125rem) | Paragraphs |
+| `body-sm` | 15px (0.9375rem) | UI text |
+| `caption` | 13px (0.8125rem) | Metadata |
+| `label` | 11px (0.6875rem) | Badges |
+
+### Line Heights
+
+| Token | Value |
+|-------|-------|
+| `display` | 0.95 |
+| `tight` | 1.15 |
+| `snug` | 1.3 |
+| `normal` | 1.5 |
+| `relaxed` | 1.65 |
+
+### Spacing Scale
+
+| Token | Size |
+|-------|------|
+| `2xs` | 2px |
+| `xs` | 4px |
+| `sm` | 8px |
+| `md` | 16px |
+| `lg` | 24px |
+| `xl` | 32px |
+| `2xl` | 48px |
+| `3xl` | 64px |
+| `4xl` | 96px |

--- a/thoughts/shared/plans/2025-12-26-typography-spacing-scale-migration.md
+++ b/thoughts/shared/plans/2025-12-26-typography-spacing-scale-migration.md
@@ -7,33 +7,33 @@ Replace 80+ hardcoded typography values and 24+ hardcoded spacing values with a 
 ## Progress Tracking
 
 ### Phase 1: Foundation (must complete first)
-- [ ] **TASK-01**: Update `globals.css` with tokens and composed classes
+- [x] **TASK-01**: Update `globals.css` with tokens and composed classes
 
 ### Phase 2: Component Migrations (parallelizable after Phase 1)
-- [ ] **TASK-02**: `src/app/page.tsx`
-- [ ] **TASK-03**: `src/components/SectionHeader.tsx`
-- [ ] **TASK-04**: `src/components/vignettes/VignetteSplit.tsx`
-- [ ] **TASK-05**: `src/components/vignettes/VignetteStaged.tsx`
-- [ ] **TASK-06**: `src/components/vignettes/VignetteContainer.tsx`
-- [ ] **TASK-07**: `src/components/vignettes/ai-highlights/HighlightsPanel.tsx`
-- [ ] **TASK-08**: `src/components/vignettes/ai-suggestions/SuggestionsPanel.tsx`
-- [ ] **TASK-09**: `src/components/vignettes/home-connect/HomeConnectPanel.tsx`
-- [ ] **TASK-10**: `src/components/vignettes/home-connect/ProblemPanel.tsx`
-- [ ] **TASK-11**: `src/components/vignettes/home-connect/TransitionPanel.tsx`
-- [ ] **TASK-12**: `src/components/vignettes/multilingual/ProblemPanel.tsx`
-- [ ] **TASK-13**: `src/components/vignettes/multilingual/TransitionPanel.tsx`
-- [ ] **TASK-14**: `src/components/vignettes/multilingual/TranslationManagementPanel.tsx`
-- [ ] **TASK-15**: `src/components/vignettes/prototyping/SandboxPanel.tsx`
-- [ ] **TASK-16**: `src/components/vignettes/vibe-coding/VibeCodingVignette.tsx`
-- [ ] **TASK-17**: `src/components/vignettes/shared/DesignNotesButton.tsx`
-- [ ] **TASK-18**: `src/components/vignettes/shared/RedlineOverlay.tsx`
-- [ ] **TASK-19**: `src/components/vignettes/shared/StageIndicator.tsx`
-- [ ] **TASK-20**: `src/components/demos/RichTextEditor.tsx`
+- [x] **TASK-02**: `src/app/page.tsx`
+- [x] **TASK-03**: `src/components/SectionHeader.tsx`
+- [x] **TASK-04**: `src/components/vignettes/VignetteSplit.tsx`
+- [x] **TASK-05**: `src/components/vignettes/VignetteStaged.tsx`
+- [x] **TASK-06**: `src/components/vignettes/VignetteContainer.tsx`
+- [x] **TASK-07**: `src/components/vignettes/ai-highlights/HighlightsPanel.tsx`
+- [x] **TASK-08**: `src/components/vignettes/ai-suggestions/SuggestionsPanel.tsx`
+- [x] **TASK-09**: `src/components/vignettes/home-connect/HomeConnectPanel.tsx`
+- [x] **TASK-10**: `src/components/vignettes/home-connect/ProblemPanel.tsx`
+- [x] **TASK-11**: `src/components/vignettes/home-connect/TransitionPanel.tsx`
+- [x] **TASK-12**: `src/components/vignettes/multilingual/ProblemPanel.tsx`
+- [x] **TASK-13**: `src/components/vignettes/multilingual/TransitionPanel.tsx`
+- [x] **TASK-14**: `src/components/vignettes/multilingual/TranslationManagementPanel.tsx`
+- [x] **TASK-15**: `src/components/vignettes/prototyping/SandboxPanel.tsx`
+- [x] **TASK-16**: `src/components/vignettes/vibe-coding/VibeCodingVignette.tsx`
+- [x] **TASK-17**: `src/components/vignettes/shared/DesignNotesButton.tsx`
+- [x] **TASK-18**: `src/components/vignettes/shared/RedlineOverlay.tsx`
+- [x] **TASK-19**: `src/components/vignettes/shared/StageIndicator.tsx`
+- [x] **TASK-20**: `src/components/demos/RichTextEditor.tsx`
 
 ### Phase 3: Cleanup (after all Phase 2 tasks)
-- [ ] **TASK-21**: Remove old CSS variables from `globals.css`
-- [ ] **TASK-22**: Update `design-notes.css`
-- [ ] **TASK-23**: Final verification
+- [x] **TASK-21**: Remove old CSS variables from `globals.css`
+- [x] **TASK-22**: Update `design-notes.css`
+- [x] **TASK-23**: Final verification
 
 ---
 

--- a/thoughts/shared/plans/2025-12-27-hero-vignette-implementation.md
+++ b/thoughts/shared/plans/2025-12-27-hero-vignette-implementation.md
@@ -1,0 +1,280 @@
+# Hero Vignette Implementation Plan
+
+## Overview
+
+Transform the static hero section into an animated "title vignette" with scroll-triggered entrance animations. Keep the copy minimal and confident: name, role, and a simple invitation to try the work. Simplify SectionHeader to remove redundant "show don't tell" messaging.
+
+## Current State Analysis
+
+**Hero Section (`src/app/page.tsx:13-26`):**
+- Static text: "Idam Adam" + "Product designer · Maker"
+- ShaderBackground component (CSS gradient animation)
+- No entry animations, no interactivity
+
+**SectionHeader ("Selected Work", lines 29-38):**
+- Contains narrative copy: "I'm a big believer in showing rather than telling..."
+- This becomes redundant now that hero says "Try the work below"
+
+**Problem:**
+- Hero is disconnected from the vignette system
+- No scroll-triggered reveal like the vignettes below
+
+## Desired End State
+
+1. **HeroVignette component** with staggered scroll-triggered animations
+2. **Minimal, confident copy**: "Idam Adam / Product Designer / Try the work below."
+3. **Simplified SectionHeader** with just "Selected Work" + "Product design at Culture Amp"
+4. **Consistent animation patterns** using existing `fadeInUp` and stagger timing
+
+**Verification:**
+- Hero animates on scroll into view
+- No redundant messaging between hero and SectionHeader
+- Reduced motion respected via existing patterns
+
+## What We're NOT Doing
+
+- Cursor-reactive shader (future enhancement)
+- Scroll-driven scene with sticky positioning
+- Typewriter/role cycling effects
+- New animation primitives (using existing patterns)
+- Changing ShaderBackground component
+
+## Implementation Approach
+
+Use existing animation patterns (`fadeInUp`, stagger) to create a polished hero that feels part of the vignette system without overcomplicating. The hero doesn't need `VignetteContainer` (no white card treatment) but will use similar animation timing.
+
+---
+
+## Phase 1: Create HeroVignette Component
+
+### Overview
+Create a new client component that wraps the hero content with Framer Motion animations. Staggered reveal of name, role, and frame-setting copy.
+
+### Changes Required:
+
+#### 1. New Component
+**File**: `src/components/HeroVignette.tsx`
+**Create**: New client component
+
+```tsx
+'use client';
+
+import { motion } from 'framer-motion';
+import ShaderBackground from './ShaderBackground';
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.15,
+      delayChildren: 0.1
+    }
+  }
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 30 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.6, ease: 'easeOut' }
+  }
+};
+
+export default function HeroVignette() {
+  return (
+    <section className="w-full py-16 lg:py-24 px-6 lg:px-12">
+      <div className="relative max-w-5xl w-full mx-auto">
+        <ShaderBackground />
+        <motion.div
+          className="space-y-5 lg:space-y-7"
+          variants={containerVariants}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, margin: "-50px" }}
+        >
+          <motion.h1 className="type-display" variants={itemVariants}>
+            Idam Adam
+          </motion.h1>
+          <motion.p className="type-body" variants={itemVariants}>
+            Product Designer
+          </motion.p>
+          <motion.p className="type-body" variants={itemVariants}>
+            Try the work below.
+          </motion.p>
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] TypeScript compiles: `npm run build`
+- [x] Linting passes: `npm run lint` (note: `npm run lint` has pre-existing config issue, but `npx eslint` passes)
+- [x] Component file exists at correct path
+
+#### Manual Verification:
+- [ ] Hero animates on page load (staggered fade-in-up)
+- [ ] Animation feels smooth, not jarring
+- [ ] Timing matches other vignette reveals
+
+---
+
+## Phase 2: Integrate and Simplify SectionHeader
+
+### Overview
+Replace inline hero markup with HeroVignette component. Simplify SectionHeader to remove the now-redundant narrative copy.
+
+### Changes Required:
+
+#### 1. Update Homepage
+**File**: `src/app/page.tsx`
+**Changes**: Import HeroVignette, replace hero section, simplify SectionHeader
+
+```tsx
+// Add import
+import HeroVignette from '@/components/HeroVignette';
+
+// Remove import (no longer used directly in page)
+// ShaderBackground is now imported only by HeroVignette
+
+export default function Home() {
+  return (
+    <main className="w-full min-h-screen bg-background text-primary">
+      {/* Hero Section - now uses HeroVignette */}
+      <HeroVignette />
+
+      {/* Vignettes Introduction - simplified */}
+      <SectionHeader title="Selected Work">
+        <p className="type-body">
+          Product design at Culture Amp
+        </p>
+      </SectionHeader>
+
+      {/* Rest unchanged... */}
+    </main>
+  );
+}
+```
+
+**Specific changes:**
+- Replace lines 13-26 (hero section) with `<HeroVignette />`
+- Remove ShaderBackground import (line 7)
+- Simplify SectionHeader content (lines 30-37) to single line
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Build succeeds: `npm run build`
+- [x] No unused imports warning
+
+#### Manual Verification:
+- [ ] Page renders correctly
+- [ ] Hero appears with animation
+- [ ] SectionHeader is now minimal ("Selected Work" + "Product design at Culture Amp")
+- [ ] No duplicate "show don't tell" messaging
+
+**Implementation Note**: After completing this phase and all automated verification passes, pause here for manual confirmation that the layout and flow feel right before proceeding.
+
+---
+
+## Phase 3: Polish and Accessibility
+
+### Overview
+Add reduced motion support and fine-tune animation timing.
+
+### Changes Required:
+
+#### 1. Add Reduced Motion Support
+**File**: `src/components/HeroVignette.tsx`
+**Changes**: Import and use `useReducedMotion` hook
+
+```tsx
+'use client';
+
+import { motion } from 'framer-motion';
+import { useReducedMotion } from '@/lib/useReducedMotion';
+import ShaderBackground from './ShaderBackground';
+
+// ... variants stay the same ...
+
+export default function HeroVignette() {
+  const reducedMotion = useReducedMotion();
+
+  // If reduced motion preferred, show content immediately
+  const animationProps = reducedMotion
+    ? { initial: false, animate: "visible" }
+    : {
+        initial: "hidden",
+        whileInView: "visible",
+        viewport: { once: true, margin: "-50px" }
+      };
+
+  return (
+    <section className="w-full py-16 lg:py-24 px-6 lg:px-12">
+      <div className="relative max-w-5xl w-full mx-auto">
+        <ShaderBackground />
+        <motion.div
+          className="space-y-5 lg:space-y-7"
+          variants={containerVariants}
+          {...animationProps}
+        >
+          {/* ... content ... */}
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+```
+
+#### 2. (Optional) Fine-tune Animation Timing
+If the stagger feels off, adjust:
+- `staggerChildren`: 0.12-0.18 range
+- `delayChildren`: 0.05-0.15 range
+- `duration`: 0.5-0.7 range
+- `margin`: "-30px" to "-100px" for earlier/later trigger
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Build succeeds: `npm run build`
+- [x] No accessibility warnings in dev tools
+
+#### Manual Verification:
+- [ ] With `prefers-reduced-motion: reduce`, content appears immediately without animation
+- [ ] Animation timing feels natural and not too slow/fast
+- [ ] Hero doesn't feel disconnected from vignettes below
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+Not applicable - this is a presentational component with no logic to test.
+
+### Manual Testing Steps:
+1. Load homepage in browser
+2. Verify hero animates on initial load (staggered reveal)
+3. Refresh page - animation should trigger again
+4. Scroll down and back up - animation should NOT retrigger (once: true)
+5. Enable reduced motion in OS settings - verify content shows immediately
+6. Check mobile viewport - verify layout stacks correctly
+7. Verify "show don't tell" copy only appears once (in hero)
+
+## Performance Considerations
+
+- No new libraries added
+- Using existing Framer Motion patterns
+- ShaderBackground unchanged (already GPU-intensive with 80px blur)
+- Reduced motion support prevents unnecessary animation for users who prefer it
+
+## References
+
+- Research document: `thoughts/shared/research/2025-12-26-hero-title-vignette-patterns.md`
+- Existing animation patterns: `src/lib/animations.ts`
+- Reduced motion hook: `src/lib/useReducedMotion.ts`
+- VignetteContainer for reference timing: `src/components/vignettes/VignetteContainer.tsx`

--- a/thoughts/shared/research/2025-12-26-font-typeface-cleanup.md
+++ b/thoughts/shared/research/2025-12-26-font-typeface-cleanup.md
@@ -1,0 +1,217 @@
+---
+date: 2025-12-26T23:15:00+11:00
+git_commit: fefc884c154ff0aef9a48fb3f30ed9c67404edc0
+branch: styling-first-pass
+repository: idamadam.com
+topic: "Font/Typeface Cleanup After Typography Scale Migration"
+tags: [research, codebase, fonts, typography, cleanup]
+status: complete
+last_updated: 2025-12-26
+last_updated_by: Claude
+---
+
+# Research: Font/Typeface Cleanup After Typography Scale Migration
+
+**Date**: 2025-12-26T23:15:00+11:00
+**Git Commit**: fefc884c154ff0aef9a48fb3f30ed9c67404edc0
+**Branch**: styling-first-pass
+**Repository**: idamadam.com
+
+## Research Question
+After implementing the typography token system, are there unused fonts being loaded that should be cleaned up?
+
+## Summary
+
+**Yes, there are 2 unused fonts that should be removed:**
+
+| Font | Variable | Status | Action |
+|------|----------|--------|--------|
+| Inter | `--font-inter` | USED | Keep (primary `--font-sans`) |
+| Geist Mono | `--font-geist-mono` | USED | Keep (`--font-mono`) |
+| Geist | `--font-geist-sans` | NOT USED | Remove |
+| IBM Plex Sans | `--font-ibm-plex-sans` | NOT USED | Remove |
+
+Additionally, there are 2 redundant inline font overrides that can be removed.
+
+## Detailed Findings
+
+### 1. Fonts Currently Loaded
+
+**File:** `src/app/layout.tsx:2-25`
+
+```typescript
+import { Geist, Geist_Mono, IBM_Plex_Sans, Inter } from "next/font/google";
+
+const geistSans = Geist({
+  variable: "--font-geist-sans",
+  subsets: ["latin"],
+});
+
+const geistMono = Geist_Mono({
+  variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+const ibmPlexSans = IBM_Plex_Sans({
+  variable: "--font-ibm-plex-sans",
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+});
+
+const inter = Inter({
+  variable: "--font-inter",
+  subsets: ["latin"],
+  weight: ["400", "600"],
+});
+```
+
+All four are applied to the body (`layout.tsx:55`):
+```typescript
+className={`${geistSans.variable} ${geistMono.variable} ${ibmPlexSans.variable} ${inter.variable} antialiased`}
+```
+
+### 2. Fonts Actually Used in Tailwind Theme
+
+**File:** `src/app/globals.css:52-54`
+
+```css
+/* Fonts - switch to Inter */
+--font-sans: var(--font-inter);
+--font-mono: var(--font-geist-mono);
+```
+
+Only `Inter` and `Geist Mono` are wired into the design system.
+
+### 3. Unused Fonts (Safe to Remove)
+
+#### Geist Sans (`--font-geist-sans`)
+- Defined in `layout.tsx:5-8`
+- Variable applied to body but never referenced anywhere
+- Was likely the original sans font before switching to Inter
+- **Zero usages in codebase**
+
+#### IBM Plex Sans (`--font-ibm-plex-sans`)
+- Defined in `layout.tsx:15-19`
+- Variable applied to body but never referenced anywhere
+- Loads 3 weights (400, 500, 600) - significant unused payload
+- Only appears in archive folder (2020 portfolio)
+- **Zero usages in current codebase**
+
+### 4. Redundant Inline Font Overrides
+
+Found 2 components explicitly setting Inter font when it's already the default:
+
+**File:** `src/components/vignettes/ai-highlights/HighlightsPanel.tsx:290`
+```tsx
+className={`bg-white border-2 border-[#a6e5e7] rounded-lg overflow-hidden font-[family-name:var(--font-inter)] ${className}`}
+```
+
+**File:** `src/components/vignettes/ai-suggestions/SuggestionsPanel.tsx:184`
+```tsx
+<div className="space-y-2 font-[family-name:var(--font-inter)]">
+```
+
+These overrides are redundant since Inter is already the default `--font-sans`.
+
+### 5. Other Fonts (Keep As-Is)
+
+#### Material Icons (CDN)
+**File:** `src/app/layout.tsx:52`
+```html
+<link href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined" rel="stylesheet" />
+```
+This is an icon font, not a text font. Keep it.
+
+#### SVG Embedded Fonts
+- Avatar SVGs use `system-ui, -apple-system, sans-serif`
+- `illustration.svg` uses `Arial, sans-serif`
+These are embedded in SVG files for rendering and don't affect page load.
+
+## Code References
+
+- `src/app/layout.tsx:2` - Font imports from next/font/google
+- `src/app/layout.tsx:5-25` - Font configurations
+- `src/app/layout.tsx:55` - Font variables applied to body
+- `src/app/globals.css:52-54` - Tailwind font mapping
+- `src/components/vignettes/ai-highlights/HighlightsPanel.tsx:290` - Redundant Inter override
+- `src/components/vignettes/ai-suggestions/SuggestionsPanel.tsx:184` - Redundant Inter override
+
+## Recommended Cleanup
+
+### Step 1: Remove Unused Font Imports
+
+In `src/app/layout.tsx`:
+
+```diff
+- import { Geist, Geist_Mono, IBM_Plex_Sans, Inter } from "next/font/google";
++ import { Geist_Mono, Inter } from "next/font/google";
+
+- const geistSans = Geist({
+-   variable: "--font-geist-sans",
+-   subsets: ["latin"],
+- });
+
+  const geistMono = Geist_Mono({
+    variable: "--font-geist-mono",
+    subsets: ["latin"],
+  });
+
+- const ibmPlexSans = IBM_Plex_Sans({
+-   variable: "--font-ibm-plex-sans",
+-   subsets: ["latin"],
+-   weight: ["400", "500", "600"],
+- });
+
+  const inter = Inter({
+    variable: "--font-inter",
+    subsets: ["latin"],
+    weight: ["400", "600"],
+  });
+```
+
+Update body className:
+```diff
+- className={`${geistSans.variable} ${geistMono.variable} ${ibmPlexSans.variable} ${inter.variable} antialiased`}
++ className={`${geistMono.variable} ${inter.variable} antialiased`}
+```
+
+### Step 2: Remove Redundant Inline Overrides
+
+In `src/components/vignettes/ai-highlights/HighlightsPanel.tsx:290`:
+```diff
+- className={`bg-white border-2 border-[#a6e5e7] rounded-lg overflow-hidden font-[family-name:var(--font-inter)] ${className}`}
++ className={`bg-white border-2 border-[#a6e5e7] rounded-lg overflow-hidden ${className}`}
+```
+
+In `src/components/vignettes/ai-suggestions/SuggestionsPanel.tsx:184`:
+```diff
+- <div className="space-y-2 font-[family-name:var(--font-inter)]">
++ <div className="space-y-2">
+```
+
+## Performance Impact
+
+Removing these unused fonts will:
+- Reduce initial page load (2 fewer font downloads)
+- IBM Plex Sans alone loads 3 weight variants
+- Cleaner codebase with fewer unused imports
+
+## Architecture Insights
+
+The codebase appears to have gone through a font transition:
+1. Originally used Geist Sans as primary font
+2. IBM Plex Sans was likely from the 2020 portfolio iteration
+3. Now standardized on Inter for body text
+4. Old font imports were never cleaned up after the migration
+
+## Open Questions
+
+### Consider Single Typeface (Inter Only)
+
+Geist Mono is only used in 5 places within `src/components/vignettes/prototyping/SandboxPanel.tsx` for terminal/code-like text. The system monospace fallback (`ui-monospace, Menlo, Monaco, Consolas`) would work equally well for this aesthetic.
+
+**Potential simplification:** Go from 4 fonts → 1 font (Inter only) by:
+1. Removing Geist Mono import
+2. Updating `--font-mono` to use system stack: `ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace`
+
+This would further reduce page load and simplify the typography system.

--- a/thoughts/shared/research/2025-12-26-hero-title-vignette-patterns.md
+++ b/thoughts/shared/research/2025-12-26-hero-title-vignette-patterns.md
@@ -1,0 +1,297 @@
+---
+date: 2025-12-26T23:50:17+11:00
+git_commit: 9349c1e02e7e7a3a7cbc47b640c036280c443a69
+branch: styling-first-pass
+repository: idamadam.com
+topic: "Hero section as interactive 'title' vignette - storytelling introduction"
+tags: [research, ux-patterns, hero, vignette, animation, storytelling]
+status: refined
+last_updated: 2025-12-26
+last_updated_by: claude
+---
+
+# Research: Hero Section as Interactive Title Vignette
+
+You want to transform your hero from static text ("Idam Adam / Product designer - Maker") into an interactive "title vignette" that's larger than other vignettes and tells a narrative story of who you are, embodying the "show don't tell" philosophy that runs through your portfolio.
+
+---
+
+## Discovery Interview Summary
+
+Through interview questions, we uncovered the following:
+
+### Who You Are (The Real Differentiators)
+| Dimension | Finding |
+|-----------|---------|
+| **Core edge** | High-trust relationships + complex projects with high design bar + deep technical understanding |
+| **Superpowers** | Ambiguous 0-to-1 problems, AI/ML product challenges, cross-team alignment |
+| **"Maker" means** | Codes production software, prototypes until indistinguishable from real, understands engineering deeply |
+| **What's broken** | Designers don't understand tech, siloed from eng reality, don't use AI to increase ambition |
+| **Your fix** | Leverage AI tools to explore MORE of the problem space, not just execute faster |
+
+### What the Hero Should Do
+| Dimension | Answer |
+|-----------|--------|
+| **Job** | Frame the story + establish presence |
+| **First feeling** | Curious |
+| **Curiosity type** | "What's different here?" |
+| **NOT doing** | Duplicating vignette demos, leading with AI angle (feels trite) |
+| **Key insight** | The vignettes below already prove skills. Hero's job is to signal the portfolio works differently. |
+
+### The Reframe
+The original "facet" idea (Designer/Maker/Collaborator with mini-demos) was **hollow** because:
+1. The vignettes below already demonstrate those skills
+2. It would feel redundant and create fatigue before the real content
+3. Generic labels don't capture what's actually different about you
+
+**The hero's real job**: Signal immediately that this portfolio is different. Create the frame that makes the vignettes land harder. The hero itself becomes the first proof of your "show don't tell" philosophy.
+
+---
+
+## Recommendation
+
+**Build a "Frame-Setting" hero vignette** that doesn't duplicate skills shown below, but instead:
+1. States who you are (name, role)
+2. Immediately breaks the "static portfolio" expectation with something interactive
+3. Creates curiosity through differentiation, not demonstration
+
+The hero becomes **meta-proof**: it demonstrates "show don't tell" by being an interactive experience, not by showing your design work.
+
+## Quick Comparison
+
+| Option | A11y | Uses Existing | Effort | Risk | Verdict |
+|--------|------|---------------|--------|------|---------|
+| A: Interactive Frame Vignette | Fully accessible | VignetteContainer, animations | 3-5h | Low | **Recommended** |
+| B: Typewriter + Role Cycling | Accessible with ARIA | New component, Framer Motion | 2-3h | Low | Lighter alternative |
+| C: Scroll-Driven Scene | Needs work | Shader, new scroll hooks | 8-12h | Med | High polish, later |
+
+## Constraints Considered
+
+- **Stack**: Next.js, Framer Motion, existing vignette patterns
+- **Existing patterns**: fadeInUp animations, ShaderBackground, VignetteContainer
+- **Priority**: Create curiosity ("what's different here?"), frame the story, establish presence
+- **NOT doing**: Skill demos (vignettes handle that), leading with AI angle
+- **Performance**: Current shader is already GPU-intensive; keep hero light
+
+---
+
+## Option A: Interactive Frame Vignette (Recommended)
+
+### Why this works
+The hero signals "this portfolio is different" by being interactive itself. It doesn't try to prove your skills (vignettes do that). Instead, it establishes presence and creates anticipation.
+
+### Concept directions to explore
+
+**Direction 1: "Invitation" Hero**
+The hero contains a subtle interactive element that invites exploration. Could be:
+- Text that responds to cursor/scroll in unexpected ways
+- A "pull to reveal" or "click to enter" moment
+- The shader background responding to interaction
+
+**Direction 2: "Portfolio as Product" Hero**
+Frame the portfolio itself as a product you designed and built. Hero text could hint at this:
+- "I believe in showing over telling. This portfolio is built to be tried, not read."
+- With a subtle CTA like "Start exploring" that scrolls to first vignette
+
+**Direction 3: "Presence-First" Hero**
+Minimal text, maximum presence. Your name + role with an interactive flourish that makes visitors pause and think "this is different." The shader could be the interaction point.
+
+### Implementation sketch (Direction 2 example)
+```tsx
+// HeroVignette.tsx
+<VignetteContainer className="min-h-[60vh]">
+  <motion.div {...fadeInUp} className="space-y-8">
+    {/* Name with subtle entrance */}
+    <motion.h1
+      className="type-display"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.8, ease: "easeOut" }}
+    >
+      Idam Adam
+    </motion.h1>
+
+    {/* Role - could have subtle animation */}
+    <p className="type-body">Product designer · Maker</p>
+
+    {/* The frame-setting line */}
+    <motion.p
+      className="type-body max-w-md"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ delay: 0.4, duration: 0.6 }}
+    >
+      I believe in showing over telling. Click through and play
+      with each feature below.
+    </motion.p>
+
+    {/* Interactive element - scroll hint or explore CTA */}
+    <ScrollInvitation />
+  </motion.div>
+</VignetteContainer>
+```
+
+### What makes this "interactive"
+The interactivity doesn't need to be complex. Options:
+1. **Cursor-reactive shader**: Background responds to mouse position
+2. **Scroll-triggered name animation**: Name animates as you scroll past
+3. **Hover states on text**: Subtle but unexpected responses
+4. **"Explore" button with micro-interaction**: Click triggers smooth scroll + animation
+
+### Similar to in codebase
+- `VignetteContainer` for consistent wrapper
+- `fadeInUp` animation preset
+- `ShaderBackground` already exists, could be enhanced
+
+### Gotchas
+- Don't over-engineer the interaction - subtle is better than gimmicky
+- The "frame-setting" copy needs to feel natural, not forced
+- Mobile needs to feel equally intentional, not a degraded experience
+
+---
+
+## Option B: Typewriter + Role Cycling
+
+### Why this works
+Simpler implementation that adds dynamism without complex panels. Your title cycles through roles with a typewriter effect, creating rhythm and intrigue. Works well if you want movement without a full interactive panel.
+
+### Implementation sketch
+```tsx
+// HeroTypewriter.tsx
+const roles = [
+  'Product Designer',
+  'Maker',
+  'Design Technologist',
+  'Builder of things'
+];
+
+<section className="hero min-h-[50vh]">
+  <h1 className="type-display">Idam Adam</h1>
+
+  <motion.div className="type-body">
+    <TypewriterCycle
+      words={roles}
+      typingSpeed={50}
+      deletingSpeed={30}
+      pauseDuration={2000}
+    />
+  </motion.div>
+
+  {/* Optional: subtle visual that changes with each role */}
+  <RoleVisual activeRole={currentRole} />
+</section>
+```
+
+### Character-by-character animation pattern
+```tsx
+// From research: stagger animation technique
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.05,  // 50ms between each letter
+      delayChildren: 0.1
+    }
+  }
+};
+
+const letterVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { type: 'spring', stiffness: 100 }
+  }
+};
+```
+
+### Gotchas
+- Typewriter can feel gimmicky if overused - keep it to one element
+- Need `aria-live="polite"` for screen reader users
+- Consider a "pause on hover" for users who want to read
+
+---
+
+## Option C: Scroll-Driven Narrative Scene
+
+### Why this works
+Creates an immersive "Bruno Simon-style" scroll experience where scrolling reveals your story. Your ShaderBackground could evolve/morph as the user scrolls, with text and visuals appearing in sequence.
+
+### Implementation sketch
+```tsx
+// HeroScene.tsx
+const { scrollYProgress } = useScroll();
+
+<section className="h-[200vh] relative">
+  {/* Sticky container that stays in view during scroll */}
+  <motion.div
+    className="sticky top-0 h-screen"
+    style={{ opacity: useTransform(scrollYProgress, [0, 0.2], [1, 0]) }}
+  >
+    <ShaderBackground intensity={scrollYProgress} />
+
+    {/* Name that scales/fades as you scroll */}
+    <motion.h1
+      style={{
+        scale: useTransform(scrollYProgress, [0, 0.5], [1, 0.8]),
+        y: useTransform(scrollYProgress, [0, 0.5], [0, -100])
+      }}
+    >
+      Idam Adam
+    </motion.h1>
+  </motion.div>
+
+  {/* Story beats that appear on scroll */}
+  <ScrollRevealSection threshold={0.3}>
+    <StoryBeat>I design products that...</StoryBeat>
+  </ScrollRevealSection>
+
+  <ScrollRevealSection threshold={0.6}>
+    <StoryBeat>And build them end-to-end...</StoryBeat>
+  </ScrollRevealSection>
+</section>
+```
+
+### Tools required
+- `useScroll` and `useTransform` from Framer Motion
+- Lenis or similar for smooth scroll (optional but recommended)
+- GSAP ScrollTrigger if more complex timeline needed
+
+### Gotchas
+- Scroll-jacking can frustrate users if not done carefully
+- Mobile performance is tricky with scroll-driven animations
+- Requires more content to justify the scroll length
+- Your existing shader might need optimization for scroll-driven updates
+
+---
+
+## What I Ruled Out
+
+- **Faceted skill demos (Designer/Maker/Collaborator)**: Hollow and redundant - vignettes below already prove skills. Creates fatigue before the real content.
+- **Leading with AI angle**: Feels trite in 2025. Let the work speak for itself.
+- **3D/WebGL Hero (Three.js/R3F)**: Too heavy for a portfolio that already has shader effects and needs fast LCP
+- **Full-page video background**: Conflicts with existing ShaderBackground and adds load time
+- **Parallax multi-layer**: Often feels dated; your current minimal aesthetic is stronger
+- **Draggable/physics-based interactions**: Cute but doesn't convey professional designer identity
+
+---
+
+## Next Steps
+
+1. **Pick a direction** from Option A (Invitation, Portfolio as Product, or Presence-First)
+2. **Sketch the copy** - what's the one line that frames the experience?
+3. **Define the interaction** - what subtle thing makes visitors pause?
+4. **Build it** - likely 3-5h with existing primitives
+
+---
+
+## Sources
+
+- [Framer Blog: Text Animation Techniques](https://www.framer.com/blog/text-animations/) - Character stagger and spring physics patterns
+- [Hover.dev Hero Components](https://www.hover.dev/components/heros) - React + Framer Motion hero examples
+- [Awwwards Freelance Portfolios](https://www.awwwards.com/awwwards/collections/freelance-portfolio/) - Best-in-class portfolio hero examples
+- [Creative Corner Studio: Scroll Animations](https://www.creativecorner.studio/blog/website-scroll-animations) - Scroll-triggered storytelling patterns
+- [Three.js Forum: Interactive 3D Portfolio](https://discourse.threejs.org/t/interactive-3d-portfolio-an-immersive-scroll-experience/44520) - Immersive scroll experience example
+- [Detachless: Hero Section Best Practices 2025](https://detachless.com/blog/hero-section-web-design-ideas) - Micro-animations and scroll-triggered patterns
+- [Joseph Collicoat: Animating Text with Framer Motion](https://www.josephcollicoat.com/articles/animating-text-with-the-intersection-observer-api-and-framer-motion) - IntersectionObserver + text animation

--- a/thoughts/shared/research/2025-12-26-portfolio-typeface-selection.md
+++ b/thoughts/shared/research/2025-12-26-portfolio-typeface-selection.md
@@ -1,0 +1,389 @@
+---
+date: 2025-12-26T23:09:29+11:00
+git_commit: 7eaa869c37057362085c39048b36e8b98400068d
+branch: styling-first-pass
+repository: idamadam.com
+topic: "Portfolio Typeface & Color System for Top Tech Companies"
+tags: [research, typography, fonts, portfolio, branding, color-system]
+status: complete
+last_updated: 2025-12-26
+last_updated_by: claude
+---
+
+# Research: Portfolio Typeface Selection for Top Tech Companies
+
+Establishing a refined typeface set for a design portfolio targeting roles at Anthropic, Apple, Vercel, Airbnb, Stripe, and similar companies.
+
+## Recommendation
+
+**Keep Inter as your primary typeface. It's the right choice.** Inter is used by designers at Apple (Johnyvino, Ethan Chng), featured prominently on Michelle Gore's portfolio, and is the foundation of Vercel's Geist design system. It signals you understand modern UI design without being trendy. For monospace, stick with Geist Mono (system mono stack is also fine). Skip adding a serif unless you're doing editorial-heavy content.
+
+Your current setup (Inter + Geist Mono) is already aligned with what designers at your target companies use. The refinement opportunity is in *how* you use these fonts (weight variation, spacing, hierarchy) rather than *which* fonts you choose.
+
+## Quick Comparison
+
+| Option | Signal | Complexity | Risk | Verdict |
+|--------|--------|------------|------|---------|
+| A: Inter only | "I ship product" | Minimal | Low | **Recommended** |
+| B: Inter + Instrument Serif | "Design-forward" | Low | Low | Good alternative |
+| C: Söhne/Aeonik (premium) | "I invest in craft" | Medium | Medium | Skip unless budget allows |
+
+## Constraints Considered
+
+- **Stack**: Next.js 16, Tailwind CSS 4, next/font/google
+- **Current setup**: Inter (body) + Geist Mono (code)
+- **Existing patterns**: Typography token system already in place
+- **Priority**: Professional credibility at top tech companies, simplicity, fast load times
+
+## What Designers at Target Companies Actually Use
+
+### Apple Designers
+| Designer | Portfolio | Primary Font | Notes |
+|----------|-----------|--------------|-------|
+| Johnyvino | johnyvino.com | **Inter** + Instrument Serif | Multi-weight Inter, serif for accents |
+| Ethan Chng | ethanchng.com | **Inter** + Inter Display | Variable fonts, SF Pro fallback |
+| Michelle Gore | michellegore.com | **Inter** + Europa + Karla | Three sans-serif layered system |
+
+### Stripe Designers
+| Designer | Portfolio | Primary Font | Notes |
+|----------|-----------|--------------|-------|
+| Karolis Kosas | karoliskosas.com | **Aeonik** | Single typeface, clean minimal |
+
+### Airbnb Designers
+| Designer | Portfolio | Primary Font | Notes |
+|----------|-----------|--------------|-------|
+| Jonathan Rahmani | jonathan.cv | **Moderat** + New Burns | Sans + serif pairing |
+| Arlen McCluskey | arlenmccluskey.com | Unknown (minimal site) | - |
+
+### Company Brand Fonts (for context)
+| Company | Website Font | Notes |
+|---------|--------------|-------|
+| Anthropic | Styrene + Tiempos | Custom brand fonts |
+| Vercel | Geist Sans/Mono | Open source, designed for UI |
+| Stripe | Söhne | Premium, geometric |
+| Linear | Inter UI | Clean, functional |
+| Apple | SF Pro | System font, not available for web |
+
+## Option A: Inter Only (Recommended)
+
+### Why this works
+Inter is the de facto standard for product design portfolios. It's used by designers at Apple, appears on Linear, and is recommended by every major portfolio guide. It signals you understand modern UI design without trying too hard. Your target companies (Anthropic, Vercel, Stripe) all hire designers who use Inter.
+
+### Implementation sketch
+```tsx
+// layout.tsx - simplified
+import { Inter } from "next/font/google";
+
+const inter = Inter({
+  variable: "--font-inter",
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"], // Add 500 for medium weight
+});
+
+// Use system mono stack instead of loading Geist Mono
+// --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace
+```
+
+### Similar to in codebase
+Already implemented. Just needs cleanup per your existing research.
+
+### Gotchas
+- Ensure you're using Inter's medium weight (500) for subtle hierarchy
+- Consider Inter Display for hero text at 48px+ for better optical balance
+- Variable font version gives you more weight options but larger file size
+
+## Option B: Inter + Instrument Serif
+
+### Why this works
+Adding a high-quality display serif creates visual interest and signals design sophistication. Johnyvino (Apple HI Designer) uses this exact pairing. Instrument Serif is free from Google Fonts and designed specifically for display use.
+
+### Implementation sketch
+```tsx
+import { Inter, Instrument_Serif } from "next/font/google";
+
+const inter = Inter({
+  variable: "--font-inter",
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+});
+
+const instrumentSerif = Instrument_Serif({
+  variable: "--font-display",
+  subsets: ["latin"],
+  weight: ["400"],
+  style: ["normal", "italic"],
+});
+
+// Use serif for hero headlines only
+// .type-display { font-family: var(--font-display); }
+```
+
+### When to use this
+- Hero headlines (display size, 48px+)
+- Section headers (sparingly)
+- Pull quotes or testimonials
+
+### Gotchas
+- Only use serif at display sizes (26px+)
+- Italic is more interesting than regular for accents
+- Don't overuse or it becomes distracting
+
+## Option C: Premium Typefaces (Söhne/Aeonik)
+
+### Why you might consider this
+Premium typefaces signal investment in craft. Stripe uses Söhne. Karolis Kosas (Stripe designer) uses Aeonik. These fonts have refined details that distinguish serious portfolios.
+
+### The fonts
+- **Söhne** (Klim Type Foundry): ~$150-300, Stripe's website font
+- **Aeonik** (CoType Foundry): ~$50-200, modern workhorse
+- **Neue Montreal** (Pangram Pangram): ~$50, trendy grotesque
+
+### Why I'm ruling this out for you
+1. Inter is free and already excellent
+2. License management adds complexity
+3. Subtle improvements don't justify cost for a job search
+4. Premium fonts can signal "style over substance" if not executed perfectly
+
+## What I Ruled Out
+
+- **Geist Sans**: Redundant with Inter, adds no value. Keep Geist Mono only for code.
+- **IBM Plex Sans**: Already removed from your codebase. It's fine but Inter is better for portfolios.
+- **Multiple sans-serif pairing**: Michelle Gore uses 3 sans-serifs which is over-engineered. One is enough.
+- **SF Pro**: Not available for web licensing. Only use if specifically building iOS demos.
+- **Playfair Display**: Too editorial/traditional for tech company portfolios.
+
+## Implementation Recommendation
+
+### Immediate (0 effort)
+Keep your current Inter + Geist Mono setup. It's correct.
+
+### Optional Enhancement (1-2h)
+1. Add Inter weight 500 (medium) for subtle hierarchy
+2. Replace Geist Mono with system mono stack (faster load, no visual difference)
+3. Consider adding Instrument Serif for hero headlines only
+
+### Your updated layout.tsx
+```tsx
+import { Inter } from "next/font/google";
+
+const inter = Inter({
+  variable: "--font-inter",
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  display: "swap",
+});
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body className={`${inter.variable} antialiased`}>
+        {children}
+      </body>
+    </html>
+  );
+}
+```
+
+### Updated globals.css
+```css
+@theme inline {
+  --font-sans: var(--font-inter);
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+```
+
+## Typography Best Practices from Top Portfolios
+
+### Common patterns observed
+1. **Single typeface dominance**: Most portfolios use one sans-serif, varied by weight
+2. **Weight hierarchy**: 400 for body, 500/600 for subheads, 700 for emphasis
+3. **Generous line-height**: 1.5-1.7 for body text
+4. **Tight tracking on headlines**: -0.02em to -0.04em
+5. **Large display sizes**: Hero text often 48-72px+
+
+### What distinguishes top portfolios
+- Consistent application (not font choice)
+- White space and restraint
+- Clear hierarchy through weight, not multiple fonts
+- High contrast between headline and body sizes
+
+## Sources
+
+- [Stripe Designer Portfolios](https://medium.com/top-designers-portfolio/4-amazing-portfolios-of-stripe-designers-1784296da55b) - Karolis Kosas uses Aeonik
+- [Apple Designer Portfolios](https://medium.com/top-designers-portfolio/4-amazing-portfolios-of-apple-designers-95eb496ea69f) - Overview of Apple designers
+- [Johnyvino Portfolio](https://johnyvino.com) - Apple HI Designer, Inter + Instrument Serif
+- [Ethan Chng Portfolio](https://ethanchng.com) - Apple Design Team 2025, Inter-based
+- [Jonathan Rahmani Portfolio](https://jonathan.cv) - Airbnb designer, Moderat + New Burns
+- [Anthropic Typography](https://type.today/en/journal/anthropic) - Uses Styrene + Tiempos
+- [Stripe Website Fonts](https://fontsinuse.com/uses/35338/stripe-website-2020) - Switched to Söhne in 2020
+- [Vercel Geist Typography](https://vercel.com/geist/typography) - Geist design system
+- [Top Portfolio Fonts 2025](https://www.playbook.com/blog/top-10-fonts-for-your-design-portfolio/) - Industry recommendations
+- [Font Pairing Trends 2025](https://pangrampangram.com/blogs/journal/best-font-pairings-2025) - Serif/sans-serif guidance
+- [Inter on Typewolf](https://www.typewolf.com/inter) - Inter usage and pairings
+
+---
+
+## Follow-up: Color System Research
+
+### Current State
+
+Your existing color system in `globals.css`:
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--background` | `#fefefe` | Page background |
+| `--foreground` | `#1a1d23` | Base text |
+| `--primary` | `#1a1d23` | Headlines |
+| `--secondary` | `#6b7280` | Body text |
+| `--tertiary` | `#9ca3af` | Captions, labels |
+| `--muted` | `#f8f9fa` | Surface backgrounds |
+| `--border` | `#e5e7eb` | Borders |
+| `--accent` | `#2563eb` | Links, focus |
+| `--warm-accent` | `#f59e0b` | Warning, highlights |
+
+### What Designer Portfolios Use
+
+| Designer | Background | Text | Accent | Theme |
+|----------|------------|------|--------|-------|
+| Karolis Kosas (Stripe) | `#ffffff` | `#000000` | `#1500ff` (blue) | Stark minimal |
+| Johnyvino (Apple) | `#1f1104` (dark brown) | `#ffffff` | `#ec662b` (rust) | Warm dark |
+| Michelle Gore (Apple) | `#ffffff` | `#000000` | Multiple pastels | Light with color |
+| Ethan Chng (Apple) | `#ffffff` | `#000000` | `#09f` / `#2f80eb` (blue) | Clean minimal |
+| Jonathan Rahmani (Airbnb) | `#1a231c` (forest) | `#ffffff` | Pastels per project | Dark with warmth |
+
+### Anthropic Brand Colors (for context)
+
+| Color | Hex | Name | Usage |
+|-------|-----|------|-------|
+| Rust/Terracotta | `#CC785C` | Antique Brass | Primary brand |
+| Warm Gray | `#828179` | Friar Gray | Secondary |
+| Off-white | `#F0EFEA` | Cararra | Backgrounds |
+| Near-black | `#141413` | Cod Gray | Text |
+| Claude Orange | `#C15F3C` | Crail | Claude brand |
+
+Anthropic's approach: warm neutrals, no pure white or black, terracotta accent.
+
+### Color System Recommendation
+
+**Your current palette is solid but could be refined.** Here's a suggested evolution:
+
+#### Option A: Refine Current (Minimal change)
+
+Keep your grays, but consider:
+1. Warm up your background slightly (pure white → off-white)
+2. Add a personality accent beyond utility blue
+3. Consider whether you want a warm or cool personality
+
+```css
+:root {
+  /* Refined neutrals - slightly warmer */
+  --background: #fafaf9;      /* Warm white (was #fefefe) */
+  --foreground: #18181b;      /* Zinc-900 (was #1a1d23) */
+  --primary: #18181b;
+  --secondary: #52525b;       /* Zinc-600 (was #6b7280) */
+  --tertiary: #a1a1aa;        /* Zinc-400 (was #9ca3af) */
+  --muted: #f4f4f5;           /* Zinc-100 (was #f8f9fa) */
+  --border: #e4e4e7;          /* Zinc-200 (was #e5e7eb) */
+
+  /* Accent - pick one direction */
+  --accent: #2563eb;          /* Keep blue for utility */
+}
+```
+
+#### Option B: Anthropic-Inspired Warm Palette
+
+Align with Anthropic's aesthetic while keeping it professional:
+
+```css
+:root {
+  /* Warm off-white background */
+  --background: #faf9f7;
+  --foreground: #1c1917;      /* Stone-900 */
+  --primary: #1c1917;
+  --secondary: #57534e;       /* Stone-600 */
+  --tertiary: #a8a29e;        /* Stone-400 */
+  --muted: #f5f5f4;           /* Stone-100 */
+  --border: #e7e5e4;          /* Stone-200 */
+
+  /* Warm accent (Anthropic-like) */
+  --accent: #c2410c;          /* Orange-700 */
+  --accent-foreground: #ffffff;
+}
+```
+
+#### Option C: High-Contrast Minimal (Like Stripe designers)
+
+Maximum restraint, let work speak:
+
+```css
+:root {
+  --background: #ffffff;
+  --foreground: #000000;
+  --primary: #000000;
+  --secondary: #525252;       /* Neutral-600 */
+  --tertiary: #a3a3a3;        /* Neutral-400 */
+  --muted: #fafafa;           /* Neutral-50 */
+  --border: #e5e5e5;          /* Neutral-200 */
+
+  /* Single sharp accent */
+  --accent: #0000ff;          /* Pure blue (like Karolis) */
+}
+```
+
+### Building a Flexible Gray Scale
+
+For future shade picking, establish a full neutral scale:
+
+```css
+:root {
+  /* Neutral scale (Zinc-based, slightly warm) */
+  --neutral-50: #fafafa;
+  --neutral-100: #f4f4f5;
+  --neutral-200: #e4e4e7;
+  --neutral-300: #d4d4d8;
+  --neutral-400: #a1a1aa;
+  --neutral-500: #71717a;
+  --neutral-600: #52525b;
+  --neutral-700: #3f3f46;
+  --neutral-800: #27272a;
+  --neutral-900: #18181b;
+  --neutral-950: #09090b;
+
+  /* Semantic mapping */
+  --background: var(--neutral-50);
+  --foreground: var(--neutral-900);
+  --primary: var(--neutral-900);
+  --secondary: var(--neutral-600);
+  --tertiary: var(--neutral-400);
+  --muted: var(--neutral-100);
+  --border: var(--neutral-200);
+}
+```
+
+This gives you the full scale to pick from while maintaining semantic tokens.
+
+### Recommendation
+
+**Go with Option A (refined current) or Option B (warm shift) based on personal preference.**
+
+| Question | Option A | Option B |
+|----------|----------|----------|
+| Do you want to feel "tech/modern"? | Yes | - |
+| Do you want to feel "crafted/warm"? | - | Yes |
+| Do you admire Anthropic's aesthetic? | - | Yes |
+| Do you want maximum neutrality? | Yes | - |
+
+Both are valid. The key insight from researching these portfolios:
+
+1. **Restraint matters more than choice** - 3-4 grays + 1 accent beats a complex palette
+2. **Warm vs cool is personality** - Neither is wrong
+3. **True black/white vs near-black/off-white** - Top designers split 50/50
+4. **Single accent color** - Almost all portfolios use one, applied sparingly
+
+### Color Sources
+
+- [Anthropic Brand Colors](https://brandfetch.com/anthropic.com) - Official palette
+- [Minimalist Color Palettes](https://hookagency.com/blog/minimalistic-color-palettes/) - Strategy guide
+- [Design System Color Tokens](https://medium.com/@tarun_design00/color-system-color-theory-primitives-semantics-tokens-567f64368d30) - Token architecture
+- [Portfolio Color Palettes](https://www.webportfolios.dev/blog/best-color-palettes-for-developer-portfolio) - Specific examples
+- [UI Color Palette Best Practices](https://www.interaction-design.org/literature/article/ui-color-palette) - IxDF guide

--- a/thoughts/shared/research/2025-12-26-premium-type-spacing-scale.md
+++ b/thoughts/shared/research/2025-12-26-premium-type-spacing-scale.md
@@ -1,0 +1,241 @@
+---
+date: 2025-12-26T22:00:49+11:00
+git_commit: e9953fbc8a0dcec0d1122d98f7ab9cc982602922
+branch: styling-first-pass
+repository: idamadam.com
+topic: "Premium Type Scale & Spacing Scale for Designer Portfolio"
+tags: [research, ux-patterns, typography, spacing, design-system, tailwind-v4]
+status: complete
+last_updated: 2025-12-26
+last_updated_by: claude
+---
+
+# Research: Premium Type Scale & Spacing Scale
+
+Creating a sleek, sophisticated typographic system suitable for a designer targeting roles at Anthropic, Apple, Stripe, Airbnb, and similar design-forward companies.
+
+## Recommendation
+
+**Use a semantic 7-size type scale with Major Third ratio (1.25), paired with an 8px-based spacing scale.** This matches what premium companies use: Vercel's Geist uses semantic naming (heading-24, copy-16, label-12), Airbnb uses named tokens referencing their DLS, and Apple uses text styles with clear hierarchy. The key differentiator isn't the sizes—it's the semantic naming that communicates intent and the disciplined constraint to just 7 levels.
+
+## Quick Comparison
+
+| Option | Sophistication | Tailwind v4 | Maintenance | Verdict |
+|--------|----------------|-------------|-------------|---------|
+| A: Semantic 7-scale | ★★★ | Native @theme | Low | **Recommended** |
+| B: Vercel-style verbose | ★★★ | Native @theme | Medium | Overkill for portfolio |
+| C: Keep abstract scale | ★☆☆ | Works | Low | Why you're here |
+
+## Constraints Considered
+
+- **Stack**: Tailwind CSS v4, Next.js 16, Geist font already configured
+- **Existing patterns**: Abstract `--text-xs` to `--text-4xl` scale exists but unused (80+ hardcoded values)
+- **Priority**: Sophistication, simplicity, and actually using the scale
+- **Context**: Designer portfolio—not a product requiring 30 typography variants
+
+---
+
+## Option A: Semantic 7-Scale (Recommended)
+
+### Why this works
+
+Premium design systems use semantic naming because it communicates intent, not just size. When a developer sees `text-body` vs `text-[18px]`, they understand the role. This is what Airbnb's "TextTitle3" and Vercel's "text-heading-24" achieve. Seven sizes covers every real use case in your portfolio without bloat.
+
+### The Type Scale
+
+Based on a **Major Third ratio (1.25)** from a 16px base, then rounded to clean values:
+
+| Token | Size | Role | Line Height | Letter Spacing |
+|-------|------|------|-------------|----------------|
+| `display` | clamp(44px, 8vw, 72px) | Hero name only | 1.05 | -0.03em |
+| `h2` | 26px (1.625rem) | Section & vignette titles | 1.15 | -0.02em |
+| `h3` | 18px (1.125rem) | Panel headings, subheadings | 1.3 | -0.01em |
+| `body` | 18px (1.125rem) | Paragraphs, descriptions | 1.65 | 0 |
+| `body-sm` | 15px (0.9375rem) | UI text, panel content | 1.5 | 0 |
+| `caption` | 13px (0.8125rem) | Metadata, timestamps | 1.45 | 0.01em |
+| `label` | 11px (0.6875rem) | Badges, micro text | 1.4 | 0.02em |
+
+**Why these specific values:**
+- `display`: Matches your existing hero clamp—responsive, dramatic
+- `h2` at 26px: Midpoint between your current 24-28px range, provides clear hierarchy without shouting
+- `h3` and `body` share 18px: Differentiated by weight (600 vs 400), matching Apple's approach where hierarchy comes from weight, not size
+- `body-sm` at 15px: Between 14px (too small for portfolio) and 16px (too close to body)
+- `caption` at 13px: Readable metadata size, Apple's minimum for secondary text
+- `label` at 11px: Matches your existing badge text, absolute minimum
+
+### Implementation (Tailwind v4)
+
+```css
+@theme inline {
+  /* Type Scale - Semantic */
+  --font-size-display: clamp(2.75rem, 8vw, 4.5rem);
+  --font-size-h2: 1.625rem;
+  --font-size-h3: 1.125rem;
+  --font-size-body: 1.125rem;
+  --font-size-body-sm: 0.9375rem;
+  --font-size-caption: 0.8125rem;
+  --font-size-label: 0.6875rem;
+
+  /* Line Heights */
+  --line-height-display: 1.05;
+  --line-height-tight: 1.15;
+  --line-height-snug: 1.3;
+  --line-height-normal: 1.5;
+  --line-height-relaxed: 1.65;
+
+  /* Letter Spacing */
+  --letter-spacing-tighter: -0.03em;
+  --letter-spacing-tight: -0.02em;
+  --letter-spacing-snug: -0.01em;
+  --letter-spacing-normal: 0;
+  --letter-spacing-wide: 0.01em;
+  --letter-spacing-wider: 0.02em;
+}
+```
+
+### Usage
+
+```tsx
+// Before (current state)
+<h2 className="text-[26px] lg:text-[28px] leading-[1.15] font-semibold tracking-tight">
+  Vignette Title
+</h2>
+<p className="text-[18px] leading-[1.7] text-[#4b5563]">
+  Description text here.
+</p>
+
+// After
+<h2 className="text-h2 leading-tight font-semibold tracking-tight">
+  Vignette Title
+</h2>
+<p className="text-body leading-relaxed text-secondary">
+  Description text here.
+</p>
+```
+
+### Why 7 sizes is enough
+
+| Current hardcoded values | Maps to |
+|--------------------------|---------|
+| `clamp(44px, 8vw, 72px)` | `display` |
+| `24px`, `26px`, `28px` | `h2` |
+| `16px`, `18px` (headings) | `h3` |
+| `18px` (body) | `body` |
+| `14px`, `15px`, `16px` (UI) | `body-sm` |
+| `12px`, `13px` | `caption` |
+| `11px` | `label` |
+
+---
+
+## The Spacing Scale
+
+### 8px Base with 4px Flexibility
+
+Premium design systems (Atlassian, Material, Apple) use an 8px base grid with 4px available for fine-tuning. This creates visual rhythm while allowing precision.
+
+| Token | Value | Use Case |
+|-------|-------|----------|
+| `2xs` | 2px | Hairline borders only |
+| `xs` | 4px | Tight padding, icon gaps |
+| `sm` | 8px | Default small gap |
+| `md` | 16px | Component padding |
+| `lg` | 24px | Section gaps |
+| `xl` | 32px | Major section breaks |
+| `2xl` | 48px | Page sections |
+| `3xl` | 64px | Hero spacing |
+| `4xl` | 96px | Major vertical rhythm |
+
+### Implementation
+
+```css
+@theme inline {
+  /* Spacing Scale */
+  --spacing-2xs: 0.125rem;  /* 2px */
+  --spacing-xs: 0.25rem;    /* 4px */
+  --spacing-sm: 0.5rem;     /* 8px */
+  --spacing-md: 1rem;       /* 16px */
+  --spacing-lg: 1.5rem;     /* 24px */
+  --spacing-xl: 2rem;       /* 32px */
+  --spacing-2xl: 3rem;      /* 48px */
+  --spacing-3xl: 4rem;      /* 64px */
+  --spacing-4xl: 6rem;      /* 96px */
+}
+```
+
+### Usage
+
+```tsx
+// Before
+<div className="p-[18px] gap-[18px] mb-[18px]">
+
+// After (use nearest scale value)
+<div className="p-md gap-md mb-md">
+```
+
+---
+
+## Option B: Vercel-Style Verbose Scale
+
+Vercel's Geist defines 30+ typography classes (`text-heading-72`, `text-copy-14`, `text-label-13-mono`, etc.). This is appropriate for a product with many surfaces, but overkill for a portfolio.
+
+### When to use this
+
+- You're building a design system for a product team
+- You need strict pixel-perfect control across dozens of views
+- You have design tooling (Figma) that generates these tokens
+
+### Why skip it here
+
+Your portfolio has ~10 active components with ~7 distinct typography needs. Adding 30 tokens creates maintenance burden without benefit.
+
+---
+
+## What I Ruled Out
+
+- **Tailwind defaults (`text-sm`, `text-lg`)**: Too generic, doesn't communicate design intent
+- **Modular scale with Golden Ratio (1.618)**: Too dramatic for a portfolio—works for marketing sites, not product-focused work
+- **Fluid typography everywhere**: The hero already uses clamp; adding fluid to body text creates unnecessary complexity for marginal gain
+- **Numbered tokens (`text-100`, `text-200`)**: Material Design uses this, but semantic names are more intuitive for a one-person project
+
+---
+
+## Implementation Priority
+
+1. **Add to `@theme inline`** in globals.css (5 min)
+2. **Update vignette foundation components** first:
+   - `VignetteStaged.tsx` - uses `text-[26px]`, `text-[18px]`
+   - `VignetteSplit.tsx` - uses `text-[26px]`
+   - `SectionHeader.tsx` - uses `text-[24px]`
+3. **Migrate panel components** - highest hardcoded count:
+   - `HighlightsPanel.tsx` (40+ instances)
+   - `HomeConnectPanel.tsx` (15+ instances)
+4. **Clean up spacing** - replace `p-[18px]`, `gap-[18px]` with scale values
+
+---
+
+## Sophistication Details
+
+What makes this feel "Anthropic/Apple/Stripe-level":
+
+1. **Negative letter-spacing on headings**: -0.02em to -0.03em creates the tight, refined look. Apple uses this heavily. Your current code has `tracking-tight` on some headings—make it consistent.
+
+2. **Relaxed line-height on body**: 1.65 instead of 1.5 gives readable, airy paragraphs. Stripe's marketing copy uses this.
+
+3. **Weight differentiation over size**: h3 and body share 18px—differentiated by weight (600 vs 400). This is how Apple's SF Text styles work.
+
+4. **Semantic color pairing**: Your `text-secondary` (#6b7280) is already well-chosen—ensure it's used consistently with `body` and `caption` text.
+
+5. **Consistent antialiasing**: You already have `-webkit-font-smoothing: antialiased`—this is essential for Geist font rendering.
+
+---
+
+## Sources
+
+- [Vercel Geist Typography](https://vercel.com/geist/typography) - Semantic class naming pattern
+- [Airbnb Design Language System](https://karrisaarinen.com/dls/) - Token-based typography with semantic names
+- [Working Type at Airbnb](https://medium.com/airbnb-design/working-type-81294544608b) - Cereal font integration and scale decisions
+- [Apple Human Interface Guidelines - Typography](https://developer.apple.com/design/human-interface-guidelines/typography) - Text styles and weight differentiation
+- [Tailwind CSS v4 Theme Variables](https://tailwindcss.com/docs/theme) - @theme inline configuration
+- [Spacing Systems & Scales](https://blog.designary.com/p/spacing-systems-and-scales-ui-design) - 8px grid rationale
+- [Modular Type Scales](https://cieden.com/book/sub-atomic/typography/establishing-a-type-scale) - Major Third ratio selection
+- [Styrene at Anthropic](https://type.today/en/journal/anthropic) - Premium typography pairing inspiration

--- a/thoughts/shared/research/2025-12-26-type-spacing-scale-audit.md
+++ b/thoughts/shared/research/2025-12-26-type-spacing-scale-audit.md
@@ -1,0 +1,342 @@
+---
+date: 2025-12-26T21:47:22+11:00
+git_commit: e9953fbc8a0dcec0d1122d98f7ab9cc982602922
+branch: main
+repository: idamadam.com
+topic: "Type Scale and Spacing Scale Consistency Audit"
+tags: [research, codebase, typography, spacing, design-system, tailwind]
+status: complete
+last_updated: 2025-12-26
+last_updated_by: claude
+last_updated_note: "Added semantic analysis and simplified type scale proposal"
+---
+
+# Research: Type Scale and Spacing Scale Consistency Audit
+
+**Date**: 2025-12-26T21:47:22+11:00
+**Git Commit**: e9953fbc8a0dcec0d1122d98f7ab9cc982602922
+**Branch**: main
+**Repository**: idamadam.com
+
+## Research Question
+
+Where are type scale and spacing scale defined in the codebase, and are they being used consistently? What's the gap between what's defined and what's actually used?
+
+## Summary
+
+**The codebase has a well-defined type and spacing scale in `globals.css`, but it's almost entirely unused.** The CSS variables and semantic classes exist but components use hardcoded Tailwind arbitrary values instead.
+
+| What's Defined | Usage |
+|----------------|-------|
+| Typography CSS vars (`--text-xs` to `--text-4xl`) | Only used within globals.css itself |
+| Spacing CSS vars (`--space-xs` to `--space-3xl`) | Only used within globals.css itself |
+| Semantic typography classes (`.text-body`, `.text-h1`, etc.) | Only used in archived case studies |
+| Hardcoded `text-[...px]` values | **80+ instances across 10 files** |
+| Hardcoded spacing `p-[...]`, `gap-[...]` | **24 instances across 4 files** |
+
+## Detailed Findings
+
+### 1. Typography CSS Variables (Defined but Not Used)
+
+**Location**: `src/app/globals.css:31-44`
+
+```css
+--text-xs: 0.75rem;    /* 12px */
+--text-sm: 0.875rem;   /* 14px */
+--text-base: 1rem;     /* 16px */
+--text-lg: 1.125rem;   /* 18px */
+--text-xl: 1.25rem;    /* 20px */
+--text-2xl: 1.5rem;    /* 24px */
+--text-3xl: 1.875rem;  /* 30px */
+--text-4xl: 2.25rem;   /* 36px */
+
+--leading-tight: 1.25;
+--leading-normal: 1.5;
+--leading-relaxed: 1.75;
+```
+
+**Usage**: Only consumed within `globals.css` to define semantic classes. No components use `var(--text-...)` directly.
+
+### 2. Spacing CSS Variables (Defined but Not Used)
+
+**Location**: `src/app/globals.css:22-29`
+
+```css
+--space-xs: 0.25rem;   /* 4px */
+--space-sm: 0.5rem;    /* 8px */
+--space-md: 1rem;      /* 16px */
+--space-lg: 1.5rem;    /* 24px */
+--space-xl: 2rem;      /* 32px */
+--space-2xl: 3rem;     /* 48px */
+--space-3xl: 4rem;     /* 64px */
+```
+
+**Usage**: Only consumed within `globals.css` for layout utility classes (`.case-study-container`, `.section-spacing`). Note: `--space-xs` and `--space-xl` are defined but never used.
+
+### 3. Semantic Typography Classes (Only in Archives)
+
+**Location**: `src/app/globals.css:152-193`
+
+| Class | Definition | Usage Count |
+|-------|------------|-------------|
+| `.text-hero` | 2.25rem, weight 700 | 3 (archived only) |
+| `.text-h1` | 1.875rem, weight 600 | 2 (archived only) |
+| `.text-h2` | 1.5rem, weight 600 | 15 (archived only) |
+| `.text-h3` | 1.25rem, weight 600 | 20 (archived only) |
+| `.text-body` | 1.125rem, relaxed | 36 (archived only) |
+| `.text-body-sm` | 1rem, normal | **0 (never used)** |
+| `.text-caption` | 0.875rem, normal | 4 (archived only) |
+
+**Key Finding**: These classes are used **120 times** but exclusively in `archive/2025-case-studies/`. The active vignette components don't use them at all.
+
+### 4. Hardcoded Typography Values (The Actual Problem)
+
+**80+ instances across 10 files** using arbitrary Tailwind values:
+
+| File | Issues | Example Values |
+|------|--------|----------------|
+| `src/app/page.tsx` | 5 | `text-[clamp(44px,8vw,72px)]`, `text-[18px]` |
+| `src/components/SectionHeader.tsx` | 1 | `text-[24px] lg:text-[26px]` |
+| `src/components/vignettes/VignetteStaged.tsx` | 2 | `text-[26px] lg:text-[28px]`, `text-[18px]` |
+| `src/components/vignettes/VignetteSplit.tsx` | 1 | `text-[26px] lg:text-[28px]` |
+| `src/components/vignettes/home-connect/HomeConnectPanel.tsx` | 15 | `text-[11px]` to `text-[22px]` |
+| `src/components/vignettes/ai-highlights/HighlightsPanel.tsx` | 40+ | `text-[14px]`, `text-[16px]`, `text-[20px]` |
+| `src/components/vignettes/ai-suggestions/SuggestionsPanel.tsx` | 4 | `text-[16px]`, `text-[20px]` |
+| `src/components/vignettes/multilingual/TranslationManagementPanel.tsx` | 4 | `text-[14px]` |
+| `src/components/vignettes/prototyping/SandboxPanel.tsx` | 2 | Various |
+| `src/components/vignettes/vibe-coding/VibeCodingVignette.tsx` | 1 | `text-[15px]` |
+
+**Common Hardcoded Sizes Observed**:
+- Hero: `clamp(44px, 8vw, 72px)`
+- H2: `24px`, `26px`, `28px`
+- Body: `18px`, `16px`, `15px`
+- Small: `14px`, `13px`, `12px`, `11px`
+
+### 5. Hardcoded Spacing Values
+
+**24 instances across 4 files**:
+
+| File | Issues |
+|------|--------|
+| `ai-suggestions/SuggestionsPanel.tsx` | `p-[2px]` |
+| `ai-highlights/HighlightsPanel.tsx` | `p-[2px]` |
+| `prototyping/SandboxPanel.tsx` | `mb-[18px]`, `gap-[18px]` |
+| `multilingual/TranslationManagementPanel.tsx` | `px-[10px]`, `py-[6px]`, `py-[8px]`, `px-[14px]` |
+
+## Architecture Insights
+
+### The Gap
+
+```
+globals.css defines:     Components actually use:
+─────────────────────    ────────────────────────
+--text-lg (18px)    →    text-[18px] leading-[1.7]
+--text-xl (20px)    →    text-[20px]
+--text-sm (14px)    →    text-[14px] leading-[20px]
+.text-body          →    (not used in active code)
+.text-h2            →    (not used in active code)
+```
+
+### Why This Happened
+
+1. **Tailwind v4 Migration**: The `@theme inline` block (lines 57-74) registers colors but not typography or spacing to Tailwind's theme
+2. **No Tailwind Integration**: CSS variables aren't accessible as Tailwind utilities (can't write `text-lg-custom`)
+3. **Semantic Classes Not Adopted**: The `.text-body`, `.text-h1` classes exist but weren't adopted when building vignettes
+4. **Historical Divergence**: Archive case studies use the semantic classes; newer vignettes use arbitrary values
+
+## Recommendations
+
+### Option A: Extend Tailwind Theme (Recommended)
+
+Add typography and spacing to `@theme inline` in globals.css:
+
+```css
+@theme inline {
+  /* Existing colors... */
+
+  /* Typography */
+  --font-size-body: var(--text-lg);
+  --font-size-body-sm: var(--text-base);
+  --font-size-caption: var(--text-sm);
+  --font-size-h1: var(--text-3xl);
+  --font-size-h2: var(--text-2xl);
+  --font-size-h3: var(--text-xl);
+
+  /* Spacing */
+  --spacing-section: var(--space-3xl);
+  --spacing-component: var(--space-lg);
+  --spacing-element: var(--space-md);
+}
+```
+
+Then use: `text-body`, `text-h2`, `gap-component`, etc.
+
+### Option B: Component-Level Constants
+
+Create a shared constants file:
+
+```typescript
+// src/lib/typography.ts
+export const typography = {
+  body: "text-lg leading-relaxed",
+  bodySm: "text-base leading-normal",
+  h2: "text-2xl font-semibold leading-tight tracking-tight",
+  // ...
+}
+```
+
+### Option C: Adopt Existing Semantic Classes
+
+Simply start using the existing `.text-body`, `.text-h1`, etc. classes that are already defined in globals.css.
+
+## Code References
+
+- `src/app/globals.css:22-44` - Scale definitions
+- `src/app/globals.css:152-193` - Semantic typography classes
+- `src/app/page.tsx:18-53` - Homepage hardcoded values
+- `src/components/vignettes/VignetteStaged.tsx:62-66` - Foundation component hardcoded values
+- `src/components/vignettes/home-connect/HomeConnectPanel.tsx` - Most hardcoded values (15+)
+- `src/components/vignettes/ai-highlights/HighlightsPanel.tsx` - Most typography violations (40+)
+
+## Open Questions
+
+1. ~~Should the responsive hero text (`clamp(44px, 8vw, 72px)`) be added to the type scale?~~ Yes, as `display`
+2. Is IBM Plex Sans font only for certain text, or should it be integrated into the type scale?
+3. ~~Should vignette "internal" typography (simulating UI) follow the scale, or is deviation acceptable for realism?~~ Yes, use the scale
+
+---
+
+## Follow-up: Semantic Analysis & Simplified Type Scale
+
+### Semantic Roles in Current Codebase
+
+Analysis of vignette components revealed typography serves these semantic roles:
+
+| HTML Concept | Current Usage | Size | Where Used |
+|--------------|---------------|------|------------|
+| `display` | Hero (name) | clamp(44-72px) | `page.tsx` hero only |
+| `h2` | Section headers, vignette titles | 24-28px | `SectionHeader`, `VignetteStaged`, `VignetteSplit` |
+| `h3` | Panel headings, subheadings | 16px | Panel components |
+| `body` | Descriptions, paragraphs | 18px | Vignette descriptions, section intros |
+| `body-sm` | Panel content, UI text | 14px | Panel internals, buttons |
+| `caption` | Metadata, timestamps | 12px | Feed items, dates |
+| `label` | Micro badges, percentages | 11px | Donut charts, tags |
+
+### The Problem with Current Scale
+
+The existing `globals.css` defines an **abstract scale** (`--text-xs` through `--text-4xl`) that mirrors Tailwind's defaults. This doesn't communicate *what* each size is for, leading developers to use arbitrary values instead.
+
+```
+Abstract (current):          Semantic (proposed):
+─────────────────────        ─────────────────────
+--text-xs   (12px)      →    --text-caption
+--text-sm   (14px)      →    --text-body-sm
+--text-base (16px)      →    --text-h3
+--text-lg   (18px)      →    --text-body
+--text-xl   (20px)      →    (unused)
+--text-2xl  (24px)      →    (merged into h2)
+--text-3xl  (30px)      →    (unused)
+--text-4xl  (36px)      →    (unused - hero uses clamp)
+```
+
+### Proposed Type Scale (7 Sizes)
+
+Replace the abstract scale with semantic names based on HTML/CSS fundamentals:
+
+```css
+/* Type Scale - Semantic names */
+--text-display: clamp(44px, 8vw, 72px);  /* Hero only */
+--text-h2: 1.625rem;                      /* 26px - titles */
+--text-h3: 1rem;                          /* 16px - subheadings */
+--text-body: 1.125rem;                    /* 18px - readable text */
+--text-body-sm: 0.875rem;                 /* 14px - UI text */
+--text-caption: 0.75rem;                  /* 12px - metadata */
+--text-label: 0.6875rem;                  /* 11px - badges */
+
+/* Line Heights - 3 options */
+--leading-tight: 1.15;                    /* Headings */
+--leading-normal: 1.5;                    /* UI text */
+--leading-relaxed: 1.65;                  /* Body copy */
+```
+
+### Why These Names
+
+Names map directly to HTML elements and CSS conventions:
+
+| Name | Rationale |
+|------|-----------|
+| `display` | CSS convention for oversized hero text (see: Bootstrap, Material) |
+| `h2` | Standard heading level - used for section/vignette titles |
+| `h3` | Standard heading level - used for panel subheadings |
+| `body` | The `<body>` default, maps to `<p>` elements |
+| `body-sm` | Smaller body variant for denser UI |
+| `caption` | HTML `<caption>` element, used for metadata |
+| `label` | HTML `<label>` element, smallest readable text |
+
+No `h1` because the hero (`display`) serves that role. No `h4`-`h6` because the current design doesn't need that depth.
+
+### Migration Path
+
+**Before:**
+```tsx
+<h2 className="text-[26px] lg:text-[28px] leading-[1.15] font-semibold">
+  Vignette Title
+</h2>
+<p className="text-[18px] leading-[1.7] text-[#4b5563]">
+  Description text here.
+</p>
+```
+
+**After:**
+```tsx
+<h2 className="text-h2 leading-tight font-semibold">
+  Vignette Title
+</h2>
+<p className="text-body leading-relaxed text-secondary">
+  Description text here.
+</p>
+```
+
+### Tailwind v4 Integration
+
+Add to `@theme inline` in `globals.css`:
+
+```css
+@theme inline {
+  /* Existing colors... */
+
+  /* Typography */
+  --font-size-display: clamp(44px, 8vw, 72px);
+  --font-size-h2: 1.625rem;
+  --font-size-h3: 1rem;
+  --font-size-body: 1.125rem;
+  --font-size-body-sm: 0.875rem;
+  --font-size-caption: 0.75rem;
+  --font-size-label: 0.6875rem;
+
+  --line-height-tight: 1.15;
+  --line-height-normal: 1.5;
+  --line-height-relaxed: 1.65;
+}
+```
+
+This enables Tailwind utilities: `text-display`, `text-h2`, `text-body`, `leading-tight`, etc.
+
+### Spacing Scale (Unchanged)
+
+The existing spacing scale is fine, just needs Tailwind integration:
+
+```css
+@theme inline {
+  /* Spacing */
+  --spacing-xs: 0.25rem;
+  --spacing-sm: 0.5rem;
+  --spacing-md: 1rem;
+  --spacing-lg: 1.5rem;
+  --spacing-xl: 2rem;
+  --spacing-2xl: 3rem;
+  --spacing-3xl: 4rem;
+}
+```
+
+Enables: `gap-md`, `p-lg`, `mt-xl`, etc.


### PR DESCRIPTION
## Summary

- **Typography system overhaul**: Replaced ad-hoc font sizes with a semantic token system (`text-display`, `text-h1`, `text-h2`, `text-h3`, `text-body`, `text-body-sm`, `text-caption`, `text-label`) with bundled line-height, letter-spacing, and font-weight properties
- **Font consolidation**: Switched from Geist/IBM Plex Sans to Inter as the single typeface
- **Color system refinement**: Added Zinc-based neutral scale with semantic mappings (`--primary`, `--secondary`, `--tertiary`) and interactive accent tokens
- **Hero vignette**: New interactive hero section with expandable design principles and dithering shader panel
- **Composed type classes**: Added `.type-*` utility classes that bundle size, weight, and color for consistent usage

## Changes

### Typography tokens (globals.css)
- `text-display`: 44-72px responsive, bold, tight tracking
- `text-h1`: 36-44px responsive, bold (new tier for hero)
- `text-h2`: 26px, semibold
- `text-h3`: 18px, semibold
- `text-body`: 18px, relaxed line-height
- `text-body-medium`: 18px, medium weight
- `text-body-sm`: 15px
- `text-caption`: 13px
- `text-label`: 11px, wide tracking

### Components updated
- All vignette components migrated to new type classes
- `VignetteSplit` now supports `variant="hero"` for larger typography
- `SectionHeader`, `VignetteContainer`, `VignetteStaged` updated

### New files
- `src/components/vignettes/hero/` - Hero vignette with shader panel
- `thoughts/shared/plans/` - Implementation planning docs
- `thoughts/shared/research/` - Typography research docs

## Test plan

- [ ] Verify hero title renders at 36-44px bold
- [ ] Check all vignettes use correct type classes
- [ ] Confirm Inter font loads correctly
- [ ] Test responsive behavior on mobile/desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)