### PR TITLE
Fix Home Connect vignette animations

### DIFF
--- a/src/components/vignettes/VignetteStaged.tsx
+++ b/src/components/vignettes/VignetteStaged.tsx
@@ -47,16 +47,11 @@ function VignetteStagedInner({
   const currentStageContent = stages?.[stage];
 
   return (
-    <motion.div
-      layout
-      className={`relative ${className}`}
-      transition={{ layout: { duration: t.stage.panelDuration, ease: 'easeInOut' } }}
-    >
+    <div className={`relative ${className}`}>
       <AnimatePresence mode="wait">
         {stage === 'designNotes' && designNotesPanel ? (
           <motion.div
             key="designNotes"
-            layout
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -10 }}
@@ -93,7 +88,6 @@ function VignetteStagedInner({
         ) : (
           <motion.div
             key="main"
-            layout
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -10 }}
@@ -133,7 +127,7 @@ function VignetteStagedInner({
           </motion.div>
         )}
       </AnimatePresence>
-    </motion.div>
+    </div>
   );
 }
 

--- a/src/components/vignettes/home-connect/HomeConnectContent.tsx
+++ b/src/components/vignettes/home-connect/HomeConnectContent.tsx
@@ -3,7 +3,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import HomeConnectPanel from './HomeConnectPanel';
-import TransitionPanel from './TransitionPanel';
 import ProblemPanel from './ProblemPanel';
 import VignetteSplit from '@/components/vignettes/VignetteSplit';
 import { useVignetteStage } from '@/components/vignettes/VignetteStaged';
@@ -14,7 +13,7 @@ import AnimatedStageText from '@/components/vignettes/shared/AnimatedStageText';
 import { DesignNotesOverlay } from '@/components/vignettes/shared/DesignNotesOverlay';
 import { useReducedMotion } from '@/lib/useReducedMotion';
 
-type PanelStage = 'problem' | 'transition' | 'solution';
+type PanelStage = 'problem' | 'solution';
 
 interface HomeConnectContentProps {
   notes: DesignNote[];
@@ -34,10 +33,6 @@ export default function HomeConnectContent({
   const reducedMotion = useReducedMotion();
 
   const handleTransition = useCallback(() => {
-    setPanelStage('transition');
-  }, []);
-
-  const handleTransitionComplete = useCallback(() => {
     setPanelStage('solution');
     goToSolution();
   }, [goToSolution]);
@@ -83,37 +78,26 @@ export default function HomeConnectContent({
         />
       }
     >
-      <div className="relative" style={{ overflow: 'visible' }}>
-        <AnimatePresence mode="sync">
+      <div className="relative min-h-[400px]" style={{ overflow: 'visible' }}>
+        <AnimatePresence mode="wait">
           {panelStage === 'problem' && (
             <motion.div
               key="problem"
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              transition={{ duration: 0.2 }}
+              transition={{ duration: 0.3, ease: 'easeInOut' }}
             >
               <ProblemPanel onTransition={handleTransition} />
-            </motion.div>
-          )}
-          {panelStage === 'transition' && (
-            <motion.div
-              key="transition"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.15 }}
-            >
-              <TransitionPanel onComplete={handleTransitionComplete} />
             </motion.div>
           )}
           {panelStage === 'solution' && (
             <motion.div
               key="solution"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0 }}
-              transition={{ duration: 0.25 }}
+              transition={{ duration: 0.4, ease: 'easeOut' }}
             >
               <HomeConnectPanel
                 highlightedSection={highlightedSection}

--- a/src/components/vignettes/home-connect/HomeConnectPanel.tsx
+++ b/src/components/vignettes/home-connect/HomeConnectPanel.tsx
@@ -148,9 +148,9 @@ export default function HomeConnectPanel({
   const getNote = (id: string) => notes.find(n => n.id === id) || { detail: '' };
 
   return (
-    <div className="w-full bg-[#F9F9F9] rounded-xl overflow-visible">
+    <div className="w-full bg-[#F9F9F9] rounded-2xl overflow-visible">
       {/* Purple header */}
-      <div className="bg-[#5F3361] px-5 pt-4 pb-4 relative">
+      <div className="bg-[#5F3361] px-5 pt-4 pb-4 relative rounded-t-2xl">
         {/* Culture Amp Logo */}
         <div className="flex items-center gap-1.5 mb-4">
           <svg width="14" height="14" viewBox="0 0 20 20" fill="none">

--- a/src/components/vignettes/home-connect/ProblemPanel.tsx
+++ b/src/components/vignettes/home-connect/ProblemPanel.tsx
@@ -14,8 +14,9 @@ const scatteredInsights = [
     icon: 'trending_up',
     color: '#5F3361',
     insight: 'Feedback due in 3 days',
-    position: { top: 0, right: 0 },
-    rotate: -2,
+    // Top center, tilted left (card is 180px wide, so offset by 90px)
+    position: { top: 0, left: 'calc(50% - 90px)' },
+    rotate: -3,
     zIndex: 1,
   },
   {
@@ -24,8 +25,9 @@ const scatteredInsights = [
     icon: 'people',
     color: '#10B981',
     insight: "Aisha's wellbeing dropped",
-    position: { top: 70, left: 0 },
-    rotate: 1,
+    // Bottom left
+    position: { bottom: 0, left: '10%' },
+    rotate: 2,
     zIndex: 2,
   },
   {
@@ -34,8 +36,9 @@ const scatteredInsights = [
     icon: 'flag',
     color: '#FFB600',
     insight: "Malik's goal is inactive",
-    position: { bottom: 0, right: 24 },
-    rotate: -1,
+    // Bottom right
+    position: { bottom: 0, right: '10%' },
+    rotate: -2,
     zIndex: 3,
   },
 ];
@@ -47,9 +50,9 @@ export default function ProblemPanel({ onTransition }: ProblemPanelProps) {
   const ctaDelay = reducedMotion ? 0 : entranceDelay + scatteredInsights.length * stagger + 0.1;
 
   return (
-    <div className="w-full">
+    <div className="w-full min-h-[400px] flex flex-col items-center justify-center">
       {/* Scattered page cards */}
-      <div className="relative h-[220px] mb-5">
+      <div className="relative h-[220px] mb-5 w-full">
         {scatteredInsights.map((item, i) => (
           <motion.div
             key={item.id}
@@ -70,23 +73,23 @@ export default function ProblemPanel({ onTransition }: ProblemPanelProps) {
             }}
           >
             {/* Window chrome header */}
-            <div className="px-2.5 py-1.5 flex items-center gap-1 bg-[#F5F5F5] border-b border-gray-200">
+            <div className="px-3 py-2 flex items-center gap-1.5 bg-[#F5F5F5] border-b border-gray-200">
               <span className="w-[6px] h-[6px] rounded-full bg-[#FF5F56]" />
               <span className="w-[6px] h-[6px] rounded-full bg-[#FFBD2E]" />
               <span className="w-[6px] h-[6px] rounded-full bg-[#27CA40]" />
               <span
-                className="material-icons-outlined text-[12px] ml-1.5"
+                className="material-icons-outlined text-[14px] ml-1"
                 style={{ color: item.color }}
               >
                 {item.icon}
               </span>
-              <span className="text-label font-medium text-gray-600">
+              <span className="text-caption font-semibold text-primary">
                 {item.page}
               </span>
             </div>
             {/* Page content */}
-            <div className="px-2.5 py-2.5 bg-white">
-              <span className="text-caption text-primary leading-tight block">{item.insight}</span>
+            <div className="px-3 py-3 bg-white">
+              <span className="text-body-sm text-primary leading-snug block">{item.insight}</span>
             </div>
           </motion.div>
         ))}

--- a/src/components/vignettes/home-connect/TransitionPanel.tsx
+++ b/src/components/vignettes/home-connect/TransitionPanel.tsx
@@ -79,9 +79,19 @@ export default function TransitionPanel({ onComplete }: TransitionPanelProps) {
   }, [state, onComplete, reducedMotion]);
 
   return (
-    <div className="w-full bg-[#F9F9F9] rounded-xl overflow-hidden">
+    <motion.div
+      className="w-full bg-[#F9F9F9] rounded-2xl overflow-hidden"
+      initial={{ opacity: 0, scale: 0.95, y: 10 }}
+      animate={{ opacity: 1, scale: 1, y: 0 }}
+      transition={{ duration: 0.4, ease: 'easeOut' }}
+    >
       {/* Purple header */}
-      <div className="bg-[#5F3361] px-5 pt-4 pb-4 relative">
+      <motion.div
+        className="bg-[#5F3361] px-5 pt-4 pb-4 relative rounded-t-2xl"
+        initial={{ opacity: 0, y: -10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3, delay: 0.1, ease: 'easeOut' }}
+      >
         <div className="flex items-center gap-1.5 mb-4">
           <svg width="14" height="14" viewBox="0 0 20 20" fill="none">
             <circle cx="10" cy="10" r="8" stroke="white" strokeWidth="2" fill="none" />
@@ -89,7 +99,7 @@ export default function TransitionPanel({ onComplete }: TransitionPanelProps) {
           <span className="text-white text-label font-semibold">Culture Amp</span>
         </div>
         <h1 className="text-white text-h3 font-bold leading-tight !m-0">Home</h1>
-      </div>
+      </motion.div>
 
       {/* Cards consolidating area */}
       <div className="relative h-[220px] flex items-center justify-center">
@@ -101,7 +111,6 @@ export default function TransitionPanel({ onComplete }: TransitionPanelProps) {
               x: card.scattered.x,
               y: card.scattered.y,
               rotate: card.scattered.rotate,
-              scale: 1,
               opacity: 1,
             }}
             animate={
@@ -110,7 +119,6 @@ export default function TransitionPanel({ onComplete }: TransitionPanelProps) {
                     x: 0,
                     y: index * 8 - 8, // Stack them slightly
                     rotate: 0,
-                    scale: state === 'complete' ? 0.9 : 0.95,
                     opacity: state === 'complete' ? 0 : 1,
                   }
                 : undefined
@@ -123,23 +131,23 @@ export default function TransitionPanel({ onComplete }: TransitionPanelProps) {
             style={{ zIndex: 3 - index }}
           >
             {/* Window chrome header */}
-            <div className="px-2.5 py-1.5 flex items-center gap-1 bg-[#F5F5F5] border-b border-gray-200">
+            <div className="px-3 py-2 flex items-center gap-1.5 bg-[#F5F5F5] border-b border-gray-200">
               <span className="w-[6px] h-[6px] rounded-full bg-[#FF5F56]" />
               <span className="w-[6px] h-[6px] rounded-full bg-[#FFBD2E]" />
               <span className="w-[6px] h-[6px] rounded-full bg-[#27CA40]" />
               <span
-                className="material-icons-outlined text-[12px] ml-1.5"
+                className="material-icons-outlined text-[14px] ml-1"
                 style={{ color: card.color }}
               >
                 {card.icon}
               </span>
-              <span className="text-label font-medium text-gray-600">
+              <span className="text-caption font-semibold text-primary">
                 {card.page}
               </span>
             </div>
             {/* Page content */}
-            <div className="px-2.5 py-2.5 bg-white">
-              <span className="text-caption text-primary leading-tight block">
+            <div className="px-3 py-3 bg-white">
+              <span className="text-body-sm text-primary leading-snug block">
                 {card.insight}
               </span>
             </div>
@@ -172,6 +180,6 @@ export default function TransitionPanel({ onComplete }: TransitionPanelProps) {
           />
         </motion.div>
       </div>
-    </div>
+    </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
- Remove `layout` props from VignetteStaged to fix janky scaling during transitions
- Remove intermediate TransitionPanel for cleaner problem→solution flow
- Arrange scattered cards in balanced triangular layout
- Improve card text hierarchy with readable styling
- Round corners to 2xl for visual consistency
- Center problem stage vertically

## Test plan
- [ ] Scroll to Home Connect vignette on homepage
- [ ] Click "What if it was all in one place?" CTA
- [ ] Verify smooth fade transition from cards to home page
- [ ] Test stage indicator navigation between problem/solution
- [ ] Check card text is readable with clear hierarchy

🤖 Generated with [Claude Code](https://claude.com/claude-code)