### PR TITLE
Rewrite Home Connect annotations in natural voice

### DIFF
--- a/src/components/vignettes/home-connect/HomeConnectPanel.tsx
+++ b/src/components/vignettes/home-connect/HomeConnectPanel.tsx
@@ -132,8 +132,12 @@ export default function HomeConnectPanel({
   notes = [],
 }: HomeConnectPanelProps) {
   // Get opacity style for a section based on what's highlighted
-  const getSectionStyle = (section: string) => {
+  const getSectionStyle = (section: string, isCard = false) => {
     if (!highlightedSection) return {};
+    // 'all-cards' keeps all cards visible
+    if (highlightedSection === 'all-cards' && isCard) {
+      return { opacity: 1, transition: 'opacity 0.2s ease-in-out' };
+    }
     return {
       opacity: highlightedSection === section ? 1 : 0.3,
       transition: 'opacity 0.2s ease-in-out',
@@ -150,7 +154,7 @@ export default function HomeConnectPanel({
   return (
     <div className="w-full bg-[#F9F9F9] rounded-2xl overflow-visible">
       {/* Purple header */}
-      <div className="bg-[#5F3361] px-5 pt-4 pb-4 relative rounded-t-2xl">
+      <div className="bg-[#5F3361] px-5 pt-4 pb-4 relative rounded-t-2xl" style={getSectionStyle('header')}>
         {/* Culture Amp Logo */}
         <div className="flex items-center gap-1.5 mb-4">
           <svg width="14" height="14" viewBox="0 0 20 20" fill="none">
@@ -170,8 +174,8 @@ export default function HomeConnectPanel({
         </motion.h1>
       </div>
 
-      {/* Content area with negative margin to overlap header */}
-      <div className="px-5 -mt-10 pb-5">
+      {/* Content area */}
+      <div className="px-5 pt-4 pb-5">
         {/* Your feed section */}
         <motion.div
           className="space-y-2.5"
@@ -179,19 +183,17 @@ export default function HomeConnectPanel({
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.15 }}
         >
-          <h2 className="text-body-sm font-bold text-primary leading-tight mb-2">Your feed</h2>
-
           <FeedDivider label="Upcoming" />
 
           {/* Performance Cycle Card */}
-          <div className="relative" style={getSectionStyle('performance')}>
+          <div className="relative" style={getSectionStyle('performance', true)}>
             <SectionMarker
               index={0}
-              noteId="progressive-disclosure"
+              noteId="card-system"
               side="right"
               isActive={highlightedSection === 'performance'}
               onOpenChange={handleNoteOpen}
-              note={getNote('progressive-disclosure')}
+              note={getNote('card-system')}
             />
             <FeedCard>
               <div className="space-y-2">
@@ -208,7 +210,7 @@ export default function HomeConnectPanel({
           </div>
 
           {/* 1-on-1 Card */}
-          <FeedCard style={getSectionStyle('oneOnOne')}>
+          <FeedCard style={getSectionStyle('oneOnOne', true)}>
             <div className="space-y-2">
               <div className="flex items-center gap-1.5">
                 <Avatar initials="AP" />
@@ -225,14 +227,14 @@ export default function HomeConnectPanel({
           <FeedDivider label="Recent" />
 
           {/* Goal Card */}
-          <div className="relative" style={getSectionStyle('goal')}>
+          <div className="relative" style={getSectionStyle('goal', true)}>
             <SectionMarker
               index={1}
-              noteId="visual-cohesion"
+              noteId="inactive-goal"
               side="left"
               isActive={highlightedSection === 'goal'}
               onOpenChange={handleNoteOpen}
-              note={getNote('visual-cohesion')}
+              note={getNote('inactive-goal')}
             />
             <FeedCard>
               <div className="flex items-center gap-3">

--- a/src/components/vignettes/home-connect/HomeConnectVignette.tsx
+++ b/src/components/vignettes/home-connect/HomeConnectVignette.tsx
@@ -10,8 +10,8 @@ import { homeConnectContent } from './content';
 
 // Map note IDs to the content sections they reference
 const NOTE_TO_SECTION: Record<string, string> = {
-  'progressive-disclosure': 'performance',
-  'visual-cohesion': 'goal',
+  'card-system': 'all-cards',
+  'inactive-goal': 'goal',
 };
 
 export default function HomeConnectVignette() {

--- a/src/components/vignettes/home-connect/content.ts
+++ b/src/components/vignettes/home-connect/content.ts
@@ -62,19 +62,19 @@ export const homeConnectContent: HomeConnectContent = {
   designNotes: {
     notes: [
       {
-        id: 'progressive-disclosure',
-        label: 'Progressive disclosure',
+        id: 'card-system',
+        label: 'Card system',
         detail:
-          'Feed items show just enough context at a glance. Details expand on interaction, reducing cognitive load.',
+          'I researched and designed a unified card system to surface updates based around the people you care about at work.',
         x: '104%',
         y: '35%',
         popoverSide: 'right' as const,
       },
       {
-        id: 'visual-cohesion',
-        label: 'Visual cohesion',
+        id: 'inactive-goal',
+        label: 'Inactive goal nudge',
         detail:
-          'Consistent card structure with type-specific accents. Each module retains identity while feeling unified.',
+          'A new notification type I designed to drive adoption. Managers can now see when their reports have stalled goals.',
         x: '-4%',
         y: '80%',
         popoverSide: 'left' as const,


### PR DESCRIPTION
## Summary
- Replaced generic design jargon ("Progressive disclosure", "Visual cohesion") with specific design decisions in my voice
- Card system annotation highlights the unified card system for people-centric updates
- Inactive goal nudge highlights the new notification type designed to drive adoption
- Updated highlighting logic so card-system shows all cards while inactive-goal shows only the goal card
- Removed redundant "Your feed" heading and fixed content overlap issue

## Test plan
- [ ] Verify Home Connect vignette loads correctly
- [ ] Check card-system annotation highlights all three cards
- [ ] Check inactive-goal annotation highlights only the goal card
- [ ] Verify no layout overlap between header and content

🤖 Generated with [Claude Code](https://claude.com/claude-code)