### PR TITLE
Redesign prototyping vignette transition to match Claude Code TUI

### DIFF
--- a/src/components/vignettes/prototyping/PrototypingVignette.tsx
+++ b/src/components/vignettes/prototyping/PrototypingVignette.tsx
@@ -19,7 +19,7 @@ function PrototypingContent() {
   const reducedMotion = useReducedMotion();
 
   const { isLoading, startTransition } = useLoadingTransition({
-    duration: 5000,
+    duration: 4000,
     onComplete: goToSolution,
   });
 

--- a/src/components/vignettes/prototyping/SandboxPanel.tsx
+++ b/src/components/vignettes/prototyping/SandboxPanel.tsx
@@ -80,72 +80,64 @@ function ProblemState({
   );
 }
 
-const setupSteps = [
-  { id: 1, command: 'npx create-next-app sandbox', label: 'Setting up React environment', delay: 0 },
-  { id: 2, command: 'npm install @kaizen/components', label: 'Adding Culture Amp design system', delay: 1.2 },
-  { id: 3, command: 'mkdir templates && touch remix.ts', label: 'Creating remix templates', delay: 2.4 },
-  { id: 4, command: 'vercel deploy --prod', label: 'Configuring deployment', delay: 3.6 },
-];
+function LoadingState({ content }: { content: PrototypingContent }) {
+  const { transitionSteps } = content;
 
-function LoadingState() {
   return (
-    <div className="bg-[#1a1d23] rounded-lg min-h-[320px] p-6 border border-gray-700">
+    <div className="relative bg-[#09090B] rounded-lg min-h-[320px] p-6 pb-12 border border-[#1f1f23] overflow-hidden">
       {/* Header */}
-      <div className="flex items-center gap-2 mb-6 pb-4 border-b border-gray-700">
-        <div className="flex gap-1.5">
-          <div className="w-3 h-3 rounded-full bg-red-500" />
-          <div className="w-3 h-3 rounded-full bg-yellow-500" />
-          <div className="w-3 h-3 rounded-full bg-green-500" />
+      <div className="flex items-center justify-between mb-6 pb-4 border-b border-[#1f1f23]">
+        <div className="flex items-center gap-2">
+          <div className="flex gap-1.5">
+            <div className="w-3 h-3 rounded-full bg-red-500" />
+            <div className="w-3 h-3 rounded-full bg-yellow-500" />
+            <div className="w-3 h-3 rounded-full bg-green-500" />
+          </div>
+          <span className="text-caption text-gray-500 font-mono ml-2">claude-code</span>
         </div>
-        <span className="text-caption text-gray-400 font-mono ml-2">Building sandbox infrastructure</span>
+        <span className="text-label text-gray-600 font-mono">~/design-sandbox</span>
       </div>
 
-      {/* Setup steps */}
-      <div className="space-y-4">
-        {setupSteps.map((step, index) => (
+      {/* Transition steps */}
+      <div className="space-y-3 font-mono">
+        {transitionSteps.map((step) => (
           <motion.div
             key={step.id}
             initial={{ opacity: 0, x: -10 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ delay: step.delay, duration: 0.3 }}
-            className="space-y-1"
           >
-            {/* Command line */}
-            <div className="flex items-center gap-2 font-mono text-caption">
-              <span className="text-gray-500">$</span>
-              <span className="text-gray-400">{step.command}</span>
-            </div>
-            {/* Status */}
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              transition={{ delay: step.delay + 0.15, duration: 0.2 }}
-              className="flex items-center gap-2 pl-4"
-            >
-              {index < setupSteps.length - 1 ? (
-                <motion.span
-                  initial={{ scale: 0 }}
-                  animate={{ scale: 1 }}
-                  transition={{ delay: step.delay + 0.2, type: 'spring', stiffness: 500 }}
-                  className="text-green-400 text-body-sm"
-                >
-                  ✓
-                </motion.span>
-              ) : (
-                <motion.span
-                  animate={{ rotate: 360 }}
-                  transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
-                  className="text-blue-400 text-body-sm"
-                >
-                  ⟳
-                </motion.span>
-              )}
-              <span className={`text-caption ${index < setupSteps.length - 1 ? 'text-gray-500' : 'text-gray-300'}`}>
-                {step.label}
-              </span>
-            </motion.div>
+            {step.type === 'command' ? (
+              <div className="flex items-center gap-2 text-caption">
+                <span className="text-[#D4A27F]">&gt;</span>
+                <span className="text-gray-100">{step.command}</span>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2 pl-4 text-caption">
+                {step.isLoading ? (
+                  <motion.span
+                    animate={{ rotate: 360 }}
+                    transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
+                    className="text-[#D4A27F]"
+                  >
+                    ⟳
+                  </motion.span>
+                ) : (
+                  <span className="text-green-400">✓</span>
+                )}
+                <span className={step.isLoading ? 'text-gray-300' : 'text-gray-500'}>
+                  {step.status}
+                </span>
+              </div>
+            )}
           </motion.div>
         ))}
+      </div>
+
+      {/* Status bar */}
+      <div className="absolute bottom-0 left-0 right-0 px-4 py-2 border-t border-[#1f1f23] flex items-center justify-between text-[11px] font-mono text-gray-500">
+        <span>opus 4.5</span>
+        <span>1.2k tokens • $0.02</span>
       </div>
     </div>
   );
@@ -187,27 +179,27 @@ function SolutionState({ content }: { content: PrototypingContent }) {
         initial={{ opacity: 0, y: 10, scale: 0.95 }}
         animate={{ opacity: 1, y: 0, scale: 1 }}
         transition={{ duration: 0.3, ease: 'easeOut', delay: 0.2 }}
-        className="absolute bottom-0 right-0 bg-[#1a1d23] rounded-lg w-[420px] shadow-2xl border border-gray-700"
+        className="absolute bottom-0 right-0 bg-[#09090B] rounded-lg w-[420px] shadow-2xl border border-[#1f1f23] overflow-hidden"
         style={{ transform: 'translate(0, 50%)' }}
       >
         {/* TUI Header */}
-        <div className="bg-[#2a2d33] px-4 py-2 rounded-t-lg border-b border-gray-700 flex items-center justify-between">
+        <div className="bg-[#111113] px-4 py-2 rounded-t-lg border-b border-[#1f1f23] flex items-center justify-between">
           <div className="flex items-center gap-2">
             <div className="flex gap-1.5">
               <div className="w-3 h-3 rounded-full bg-red-500" />
               <div className="w-3 h-3 rounded-full bg-yellow-500" />
               <div className="w-3 h-3 rounded-full bg-green-500" />
             </div>
-            <span className="text-caption text-gray-400 font-mono ml-2">claude-code</span>
+            <span className="text-caption text-gray-500 font-mono ml-2">claude-code</span>
           </div>
-          <span className="text-label text-gray-500 font-mono">~/.../sandbox</span>
+          <span className="text-label text-gray-600 font-mono">~/.../sandbox</span>
         </div>
 
         {/* TUI Content */}
-        <div className="p-4 font-mono text-caption leading-relaxed">
+        <div className="p-4 pb-10 font-mono text-caption leading-relaxed">
           {/* Command prompt */}
           <div className="flex items-start gap-2 mb-3">
-            <span className="text-blue-400 select-none">❯</span>
+            <span className="text-[#D4A27F] select-none">&gt;</span>
             <span className="text-gray-100">/remix Idam&apos;s prototype and make it my own</span>
           </div>
 
@@ -230,13 +222,19 @@ function SolutionState({ content }: { content: PrototypingContent }) {
               <motion.span
                 animate={{ rotate: 360 }}
                 transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
-                className="text-blue-400"
+                className="text-[#D4A27F]"
               >
                 ⟳
               </motion.span>
               <span className="text-gray-300">Customizing components...</span>
             </div>
           </motion.div>
+        </div>
+
+        {/* Status bar */}
+        <div className="absolute bottom-0 left-0 right-0 px-4 py-2 border-t border-[#1f1f23] rounded-b-lg flex items-center justify-between text-[11px] font-mono text-gray-500">
+          <span>opus 4.5</span>
+          <span>2.4k tokens • $0.04</span>
         </div>
       </motion.div>
     </div>
@@ -275,7 +273,7 @@ export default function SandboxPanel({
             exit={{ opacity: 0, scale: 0.98 }}
             transition={{ duration: 0.3 }}
           >
-            <LoadingState />
+            <LoadingState content={content} />
           </motion.div>
         );
       default:

--- a/src/components/vignettes/prototyping/content.ts
+++ b/src/components/vignettes/prototyping/content.ts
@@ -12,11 +12,21 @@ export interface ProblemQuestion {
   delay: number; // stagger delay for animation
 }
 
+export interface TransitionStep {
+  id: string;
+  type: 'command' | 'status' | 'tip';
+  command?: string;
+  status?: string;
+  isLoading?: boolean;
+  delay: number;
+}
+
 export interface PrototypingContent {
   stages: VignetteStages;
   sandboxTitle: string;
   prototypes: PrototypeItem[];
   problemQuestions: ProblemQuestion[];
+  transitionSteps: TransitionStep[];
   adoptionStats: {
     designers: number;
     prototypes: number;
@@ -49,6 +59,13 @@ export const prototypingContent: PrototypingContent = {
     { id: 'q2', text: 'What tools do I use?', delay: 0.15 },
     { id: 'q3', text: 'How do I set up an environment?', delay: 0.3 },
     { id: 'q4', text: 'How do I share this?', delay: 0.45 }
+  ],
+  transitionSteps: [
+    { id: 'clone-cmd', type: 'command', command: 'git clone culture-amp/design-sandbox', delay: 0 },
+    { id: 'clone-status', type: 'status', status: 'Cloned — Components ready', delay: 0.8 },
+    { id: 'prototype-cmd', type: 'command', command: '/new-prototype "My feature idea"', delay: 1.8 },
+    { id: 'prototype-status', type: 'status', status: 'Created workspace', delay: 2.6 },
+    { id: 'opening-status', type: 'status', status: 'Opening your prototype...', isLoading: true, delay: 3.4 },
   ],
   adoptionStats: {
     designers: 12,


### PR DESCRIPTION
## Summary
- Replace generic terminal commands with authentic Claude Code slash command experience
- Show the actual workflow I built: `git clone` → `/new-prototype`
- Apply Anthropic design system colors (`#09090B` background, `#D4A27F` tan accent)
- Add status bar showing model and token info for authenticity
- Consistent styling across transition and solution states

## Test plan
- [ ] Verify transition animation plays smoothly
- [ ] Check colors match Claude Code TUI appearance
- [ ] Confirm status bar displays correctly on both panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)