### PR TITLE
Improve mobile responsiveness across vignettes

### DIFF
--- a/src/components/demos/RichTextEditor.tsx
+++ b/src/components/demos/RichTextEditor.tsx
@@ -28,27 +28,30 @@ export default function RichTextEditor({
       <div className="bg-white border-2 border-[#878792] rounded-lg overflow-hidden">
         {/* Toolbar */}
         <div className="bg-white flex items-center gap-1.5 p-1.5">
-          {/* Text formatting */}
-          <button className="bg-white hover:bg-gray-50 p-3.5 rounded-lg size-12 flex items-center justify-center transition-colors">
-            <span className="material-icons-outlined text-h3 text-primary">format_bold</span>
-          </button>
-          <button className="bg-white hover:bg-gray-50 p-3.5 rounded-lg size-12 flex items-center justify-center transition-colors">
-            <span className="material-icons-outlined text-h3 text-primary">format_italic</span>
-          </button>
-          <button className="bg-white hover:bg-gray-50 p-3.5 rounded-lg size-12 flex items-center justify-center transition-colors">
-            <span className="material-icons-outlined text-h3 text-primary">format_underlined</span>
-          </button>
+          {/* Formatting buttons - hidden on mobile */}
+          <div className="hidden sm:flex items-center gap-1.5">
+            {/* Text formatting */}
+            <button className="bg-white hover:bg-gray-50 p-3.5 rounded-lg size-12 flex items-center justify-center transition-colors">
+              <span className="material-icons-outlined text-h3 text-primary">format_bold</span>
+            </button>
+            <button className="bg-white hover:bg-gray-50 p-3.5 rounded-lg size-12 flex items-center justify-center transition-colors">
+              <span className="material-icons-outlined text-h3 text-primary">format_italic</span>
+            </button>
+            <button className="bg-white hover:bg-gray-50 p-3.5 rounded-lg size-12 flex items-center justify-center transition-colors">
+              <span className="material-icons-outlined text-h3 text-primary">format_underlined</span>
+            </button>
 
-          {/* Divider */}
-          <div className="h-12 w-px bg-[rgba(82,78,86,0.1)] mx-0.5" />
+            {/* Divider */}
+            <div className="h-12 w-px bg-[rgba(82,78,86,0.1)] mx-0.5" />
 
-          {/* List button */}
-          <button className="bg-white hover:bg-gray-50 p-3.5 rounded-lg size-12 flex items-center justify-center transition-colors">
-            <span className="material-icons-outlined text-h3 text-primary">format_list_bulleted</span>
-          </button>
+            {/* List button */}
+            <button className="bg-white hover:bg-gray-50 p-3.5 rounded-lg size-12 flex items-center justify-center transition-colors">
+              <span className="material-icons-outlined text-h3 text-primary">format_list_bulleted</span>
+            </button>
 
-          {/* Divider */}
-          <div className="h-12 w-px bg-[rgba(82,78,86,0.1)] mx-0.5" />
+            {/* Divider */}
+            <div className="h-12 w-px bg-[rgba(82,78,86,0.1)] mx-0.5" />
+          </div>
 
           {/* Improve button */}
           {showImproveButton && (

--- a/src/components/vignettes/ai-highlights/HighlightsPanel.tsx
+++ b/src/components/vignettes/ai-highlights/HighlightsPanel.tsx
@@ -158,18 +158,18 @@ function LoadingState() {
               key={index}
               className={`px-6 py-8 ${index < 2 ? 'border-b-2 border-[#eaeaec]' : ''}`}
             >
-              <div className="flex items-center justify-between">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
                 <div className="flex-1 space-y-2">
                   <div className="flex items-center gap-1">
                     <div className="skeleton-bar w-5 h-5 rounded-full" />
-                    <div className="skeleton-bar h-[15px] w-[85px] rounded-[7px]" />
+                    <div className="skeleton-bar h-[15px] w-20 sm:w-[85px] rounded-[7px]" />
                   </div>
-                  <div className="skeleton-bar h-[15px] w-[240px] rounded-[7px]" />
+                  <div className="skeleton-bar h-[15px] w-full max-w-[240px] rounded-[7px]" />
                 </div>
-                <div className="flex items-center gap-12">
+                <div className="flex items-center gap-4 sm:gap-12">
                   <div className="flex items-center gap-1">
                     <div className="skeleton-bar w-5 h-5 rounded-full" />
-                    <div className="skeleton-bar h-[15px] w-[60px] rounded-[7px]" />
+                    <div className="skeleton-bar h-[15px] w-14 sm:w-[60px] rounded-[7px]" />
                   </div>
                   <div className="skeleton-bar w-5 h-5 rounded-full" />
                 </div>
@@ -193,16 +193,40 @@ const feedbackCardPositions = [
 
 function ProblemState({ cards, onTransition }: { cards: FeedbackSource[]; onTransition?: () => void }) {
   const { entranceDelay, stagger } = useVignetteEntrance();
-  // Use first 5 cards for scattered layout
   const displayCards = cards.slice(0, 5);
-
-  // CTA appears after all cards have animated in
   const ctaDelay = entranceDelay + displayCards.length * stagger + 0.1;
 
   return (
-    <div className="relative bg-gray-50 border-2 border-dashed border-gray-300 rounded-lg min-h-[400px] flex flex-col items-center justify-end p-8 overflow-hidden">
-      {/* Scattered floating cards */}
-      <div className="absolute inset-0">
+    <div className="relative bg-gray-50 border-2 border-dashed border-gray-300 rounded-lg min-h-[300px] lg:min-h-[400px] flex flex-col items-center justify-end p-4 lg:p-8 overflow-hidden">
+      {/* Mobile: Simple stacked layout */}
+      <div className="flex flex-col gap-3 w-full mb-4 lg:hidden">
+        {displayCards.slice(0, 3).map((card, index) => (
+          <motion.div
+            key={card.id}
+            className="bg-white px-4 py-3 rounded-lg shadow-sm border border-gray-200"
+            initial={{ opacity: 0, y: 20, scale: 0.9 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            transition={{
+              duration: 0.4,
+              delay: entranceDelay + index * stagger,
+              ease: 'easeOut' as const,
+            }}
+          >
+            {card.from && (
+              <div className="flex items-center gap-2 mb-2">
+                {card.avatarUrl && (
+                  <img src={card.avatarUrl} alt={card.from} className="w-6 h-6 rounded-full" />
+                )}
+                <span className="text-body-sm font-semibold text-primary">{card.from}</span>
+              </div>
+            )}
+            <p className="text-body-sm text-secondary line-clamp-2">{card.content}</p>
+          </motion.div>
+        ))}
+      </div>
+
+      {/* Desktop: Scattered absolute positioning */}
+      <div className="absolute inset-0 hidden lg:block">
         {displayCards.map((card, index) => {
           const pos = feedbackCardPositions[index % feedbackCardPositions.length];
           return (
@@ -226,20 +250,12 @@ function ProblemState({ cards, onTransition }: { cards: FeedbackSource[]; onTran
               {card.from && (
                 <div className="flex items-center gap-2 mb-2">
                   {card.avatarUrl && (
-                    <img
-                      src={card.avatarUrl}
-                      alt={card.from}
-                      className="w-6 h-6 rounded-full"
-                    />
+                    <img src={card.avatarUrl} alt={card.from} className="w-6 h-6 rounded-full" />
                   )}
-                  <span className="text-body-sm font-semibold text-primary">
-                    {card.from}
-                  </span>
+                  <span className="text-body-sm font-semibold text-primary">{card.from}</span>
                 </div>
               )}
-              <p className="text-body-sm text-secondary line-clamp-3">
-                {card.content}
-              </p>
+              <p className="text-body-sm text-secondary line-clamp-3">{card.content}</p>
             </motion.div>
           );
         })}

--- a/src/components/vignettes/home-connect/ProblemPanel.tsx
+++ b/src/components/vignettes/home-connect/ProblemPanel.tsx
@@ -50,9 +50,46 @@ export default function ProblemPanel({ onTransition }: ProblemPanelProps) {
   const ctaDelay = reducedMotion ? 0 : entranceDelay + scatteredInsights.length * stagger + 0.1;
 
   return (
-    <div className="w-full min-h-[400px] flex flex-col items-center justify-center">
-      {/* Scattered page cards */}
-      <div className="relative h-[220px] mb-5 w-full">
+    <div className="w-full min-h-[300px] lg:min-h-[400px] flex flex-col items-center justify-center p-4 lg:p-0">
+      {/* Mobile: Stacked cards */}
+      <div className="flex flex-col gap-3 w-full mb-4 lg:hidden">
+        {scatteredInsights.map((item, i) => (
+          <motion.div
+            key={item.id}
+            className="w-full bg-[#F9F9F9] rounded-lg overflow-hidden shadow-[0px_4px_12px_0px_rgba(0,0,0,0.1)]"
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{
+              delay: reducedMotion ? 0 : entranceDelay + i * stagger,
+              duration: 0.4,
+              ease: 'easeOut' as const,
+            }}
+          >
+            {/* Window chrome header */}
+            <div className="px-3 py-2 flex items-center gap-1.5 bg-[#F5F5F5] border-b border-gray-200">
+              <span className="w-[6px] h-[6px] rounded-full bg-[#FF5F56]" />
+              <span className="w-[6px] h-[6px] rounded-full bg-[#FFBD2E]" />
+              <span className="w-[6px] h-[6px] rounded-full bg-[#27CA40]" />
+              <span
+                className="material-icons-outlined text-[14px] ml-1"
+                style={{ color: item.color }}
+              >
+                {item.icon}
+              </span>
+              <span className="text-caption font-semibold text-primary">
+                {item.page}
+              </span>
+            </div>
+            {/* Page content */}
+            <div className="px-3 py-3 bg-white">
+              <span className="text-body-sm text-primary leading-snug block">{item.insight}</span>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+
+      {/* Desktop: Scattered page cards */}
+      <div className="relative h-[220px] mb-5 w-full hidden lg:block">
         {scatteredInsights.map((item, i) => (
           <motion.div
             key={item.id}

--- a/src/components/vignettes/prototyping/SandboxPanel.tsx
+++ b/src/components/vignettes/prototyping/SandboxPanel.tsx
@@ -21,16 +21,32 @@ function ProblemState({
   onTransition?: () => void;
 }) {
   const { entranceDelay, stagger } = useVignetteEntrance();
-
-  // CTA appears after all questions have animated in
   const ctaDelay = entranceDelay + questions.length * stagger + 0.1;
 
   return (
-    <div className="relative bg-gray-50 border-2 border-dashed border-gray-300 rounded-lg min-h-[320px] flex flex-col items-center justify-center p-8">
-      {/* Floating questions */}
-      <div className="relative w-full h-36">
+    <div className="relative bg-gray-50 border-2 border-dashed border-gray-300 rounded-lg min-h-[280px] lg:min-h-[320px] flex flex-col items-center justify-center p-4 lg:p-8">
+      {/* Mobile: Stacked questions */}
+      <div className="flex flex-col gap-2 w-full mb-4 lg:hidden">
+        {questions.map((q, index) => (
+          <motion.div
+            key={q.id}
+            className="bg-white px-4 py-2 rounded-lg shadow-sm border border-gray-200 text-body-sm text-gray-600 font-medium"
+            initial={{ opacity: 0, y: 20, scale: 0.9 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            transition={{
+              duration: 0.4,
+              delay: entranceDelay + index * stagger,
+              ease: 'easeOut' as const,
+            }}
+          >
+            {q.text}
+          </motion.div>
+        ))}
+      </div>
+
+      {/* Desktop: Scattered floating questions */}
+      <div className="relative w-full h-36 hidden lg:block">
         {questions.map((q, index) => {
-          // Position questions in a scattered pattern
           const positions = [
             { top: '10%', left: '5%', rotate: -5 },
             { top: '5%', right: '10%', rotate: 3 },
@@ -48,11 +64,7 @@ function ProblemState({
                 transform: `rotate(${pos.rotate}deg)`,
               }}
               initial={{ opacity: 0, y: 20, scale: 0.9 }}
-              animate={{
-                opacity: 1,
-                y: 0,
-                scale: 1,
-              }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
               transition={{
                 duration: 0.4,
                 delay: entranceDelay + index * stagger,
@@ -68,7 +80,7 @@ function ProblemState({
       {/* CTA */}
       <motion.button
         onClick={onTransition}
-        className="btn-interactive btn-primary mt-6"
+        className="btn-interactive btn-primary mt-4 lg:mt-6"
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: ctaDelay, duration: 0.3 }}
@@ -162,11 +174,11 @@ function SolutionState({ content }: { content: PrototypingContent }) {
         </div>
 
         {/* Prototype Grid */}
-        <div className="grid grid-cols-3 gap-lg">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 sm:gap-lg">
           {content.prototypes.map((item) => (
             <div
               key={item.id}
-              className="rounded-[7px] h-[78px]"
+              className="rounded-[7px] h-[60px] sm:h-[78px]"
               style={{ backgroundColor: item.thumbnail }}
               aria-label={item.name}
             />
@@ -179,7 +191,7 @@ function SolutionState({ content }: { content: PrototypingContent }) {
         initial={{ opacity: 0, y: 10, scale: 0.95 }}
         animate={{ opacity: 1, y: 0, scale: 1 }}
         transition={{ duration: 0.3, ease: 'easeOut', delay: 0.2 }}
-        className="absolute bottom-0 right-0 bg-[#09090B] rounded-lg w-[420px] shadow-2xl border border-[#1f1f23] overflow-hidden"
+        className="absolute bottom-0 right-0 left-0 sm:left-auto bg-[#09090B] rounded-lg w-full sm:w-[340px] lg:w-[420px] shadow-2xl border border-[#1f1f23] overflow-hidden"
         style={{ transform: 'translate(0, 50%)' }}
       >
         {/* TUI Header */}

--- a/src/components/vignettes/vibe-coding/DemoCreationFlow.tsx
+++ b/src/components/vignettes/vibe-coding/DemoCreationFlow.tsx
@@ -11,13 +11,13 @@ interface Message {
 }
 
 const DEMO_MESSAGES: Message[] = [
-  { delay: 0, text: 'Create a task card with priority badges', type: 'user' },
-  { delay: 400, text: 'I\'ll create an interactive task card component with priority badges and a clean design.', type: 'assistant' },
-  { delay: 1000, text: 'Writing App.tsx', type: 'tool', icon: '📝' },
-  { delay: 1400, text: 'Writing Badge.tsx', type: 'tool', icon: '📝' },
-  { delay: 1800, text: 'Writing styles.css', type: 'tool', icon: '🎨' },
-  { delay: 2200, text: 'Compiling prototype', type: 'tool', icon: '⚡' },
-  { delay: 2600, text: '✓ Prototype created successfully', type: 'success' }
+  { delay: 0, text: 'Create a vignette for my portfolio homepage', type: 'user' },
+  { delay: 400, text: 'I\'ll create an interactive vignette with staged reveals and design annotations.', type: 'assistant' },
+  { delay: 1000, text: 'Writing Vignette.tsx', type: 'tool', icon: '📝' },
+  { delay: 1400, text: 'Writing Panel.tsx', type: 'tool', icon: '📝' },
+  { delay: 1800, text: 'Writing content.ts', type: 'tool', icon: '✏️' },
+  { delay: 2200, text: 'Adding animations', type: 'tool', icon: '✨' },
+  { delay: 2600, text: '✓ Vignette created successfully', type: 'success' }
 ];
 
 const RESULT_DELAY = 3200;
@@ -117,7 +117,7 @@ export default function DemoCreationFlow({ onComplete }: DemoCreationFlowProps) 
         <div className="h-12 bg-white border-b border-gray-200 flex items-center justify-between px-4">
           <div className="flex items-center space-x-3">
             <div className="w-2 h-2 rounded-full bg-gray-400"></div>
-            <span className="text-sm font-medium text-gray-600">Task Card Demo</span>
+            <span className="text-sm font-medium text-gray-600">Vignette Demo</span>
           </div>
           <div className="flex items-center space-x-2">
             <div className="px-3 py-1 bg-gray-100 rounded-md text-xs text-gray-600 font-medium">
@@ -209,39 +209,45 @@ export default function DemoCreationFlow({ onComplete }: DemoCreationFlowProps) 
               }`}
             >
               {showResult ? (
-                <div className="border border-gray-200 rounded-xl bg-white shadow-xl">
-                  <div className="p-6">
-                    {/* Badges */}
-                    <div className="flex flex-wrap items-center gap-2 mb-3">
-                      <span className="px-2.5 py-1 bg-red-100 text-red-700 text-xs font-semibold rounded-full">
-                        High Priority
-                      </span>
-                      <span className="px-2.5 py-1 bg-blue-100 text-blue-700 text-xs font-semibold rounded-full">
-                        Design
-                      </span>
-                    </div>
-
-                    {/* Title */}
-                    <h4 className="text-lg font-semibold text-gray-900 mb-2">
-                      Update landing page hero
-                    </h4>
-
-                    {/* Description */}
-                    <p className="text-gray-600 text-sm leading-relaxed mb-4">
-                      Revise the main headline and add a compelling demo section to showcase the product in action.
-                    </p>
-
-                    {/* Footer */}
-                    <div className="flex items-center justify-between pt-4 border-t border-gray-100">
-                      <div className="flex items-center gap-2 text-sm text-gray-500">
-                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                        </svg>
-                        <span>Due in 3 days</span>
+                <div className="border border-neutral-200 rounded-2xl bg-white shadow-xl overflow-hidden ring-1 ring-amber-500/20">
+                  <div className="p-4">
+                    {/* Mini VignetteSplit layout */}
+                    <div className="grid grid-cols-[90px_1fr] gap-3 items-start">
+                      {/* Left: Title + Description */}
+                      <div className="space-y-1">
+                        <h4 className="text-[11px] font-semibold text-gray-900 leading-tight">
+                          AI Suggestions
+                        </h4>
+                        <p className="text-[9px] text-gray-500 leading-relaxed">
+                          Contextual improvements for reviews
+                        </p>
+                        {/* Mini CTA */}
+                        <button className="mt-2 px-2 py-1 bg-gray-900 text-white text-[8px] font-medium rounded-md">
+                          See solution
+                        </button>
                       </div>
-                      <button className="px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 transition-colors">
-                        View Details
-                      </button>
+
+                      {/* Right: Mini Panel */}
+                      <div className="bg-neutral-50 rounded-lg p-2.5 border border-neutral-100">
+                        {/* Mini text editor area */}
+                        <div className="bg-white rounded border border-neutral-200 p-2 mb-2">
+                          <div className="space-y-1">
+                            <div className="h-1.5 bg-gray-200 rounded w-full"></div>
+                            <div className="h-1.5 bg-gray-200 rounded w-4/5"></div>
+                            <div className="h-1.5 bg-amber-200 rounded w-3/5"></div>
+                            <div className="h-1.5 bg-gray-200 rounded w-full"></div>
+                          </div>
+                        </div>
+                        {/* Mini suggestion card */}
+                        <div className="bg-white rounded border border-amber-200 p-1.5">
+                          <div className="flex items-center gap-1">
+                            <div className="w-3 h-3 rounded-full bg-amber-100 flex items-center justify-center">
+                              <span className="text-[6px]">💡</span>
+                            </div>
+                            <div className="h-1 bg-gray-300 rounded flex-1"></div>
+                          </div>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -347,39 +353,45 @@ export default function DemoCreationFlow({ onComplete }: DemoCreationFlowProps) 
                 className="w-full h-full bg-gray-100 flex items-center justify-center p-6"
               >
                 <div className="w-full max-w-[280px]">
-                  <div className="border border-gray-200 rounded-xl bg-white shadow-xl">
-                    <div className="p-6">
-                      {/* Badges */}
-                      <div className="flex flex-wrap items-center gap-2 mb-3">
-                        <span className="px-2.5 py-1 bg-red-100 text-red-700 text-xs font-semibold rounded-full">
-                          High Priority
-                        </span>
-                        <span className="px-2.5 py-1 bg-blue-100 text-blue-700 text-xs font-semibold rounded-full">
-                          Design
-                        </span>
-                      </div>
-
-                      {/* Title */}
-                      <h4 className="text-lg font-semibold text-gray-900 mb-2">
-                        Update landing page hero
-                      </h4>
-
-                      {/* Description */}
-                      <p className="text-gray-600 text-sm leading-relaxed mb-4">
-                        Revise the main headline and add a compelling demo section to showcase the product in action.
-                      </p>
-
-                      {/* Footer */}
-                      <div className="flex items-center justify-between pt-4 border-t border-gray-100">
-                        <div className="flex items-center gap-2 text-sm text-gray-500">
-                          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                          </svg>
-                          <span>Due in 3 days</span>
+                  <div className="border border-neutral-200 rounded-2xl bg-white shadow-xl overflow-hidden ring-1 ring-amber-500/20">
+                    <div className="p-5">
+                      {/* Mini VignetteSplit layout */}
+                      <div className="grid grid-cols-[100px_1fr] gap-4 items-start">
+                        {/* Left: Title + Description */}
+                        <div className="space-y-1.5">
+                          <h4 className="text-xs font-semibold text-gray-900 leading-tight">
+                            AI Suggestions
+                          </h4>
+                          <p className="text-[10px] text-gray-500 leading-relaxed">
+                            Contextual improvements for reviews
+                          </p>
+                          {/* Mini CTA */}
+                          <button className="mt-2 px-2.5 py-1 bg-gray-900 text-white text-[9px] font-medium rounded-md">
+                            See solution
+                          </button>
                         </div>
-                        <button className="px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 transition-colors">
-                          View Details
-                        </button>
+
+                        {/* Right: Mini Panel */}
+                        <div className="bg-neutral-50 rounded-lg p-3 border border-neutral-100">
+                          {/* Mini text editor area */}
+                          <div className="bg-white rounded border border-neutral-200 p-2 mb-2">
+                            <div className="space-y-1.5">
+                              <div className="h-1.5 bg-gray-200 rounded w-full"></div>
+                              <div className="h-1.5 bg-gray-200 rounded w-4/5"></div>
+                              <div className="h-1.5 bg-amber-200 rounded w-3/5"></div>
+                              <div className="h-1.5 bg-gray-200 rounded w-full"></div>
+                            </div>
+                          </div>
+                          {/* Mini suggestion card */}
+                          <div className="bg-white rounded border border-amber-200 p-2">
+                            <div className="flex items-center gap-1.5">
+                              <div className="w-4 h-4 rounded-full bg-amber-100 flex items-center justify-center">
+                                <span className="text-[8px]">💡</span>
+                              </div>
+                              <div className="h-1.5 bg-gray-300 rounded flex-1"></div>
+                            </div>
+                          </div>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/src/components/vignettes/vibe-coding/DemoCreationFlow.tsx
+++ b/src/components/vignettes/vibe-coding/DemoCreationFlow.tsx
@@ -101,26 +101,26 @@ export default function DemoCreationFlow({ onComplete }: DemoCreationFlowProps) 
   return (
     <div ref={containerRef} className="w-full">
       {/* Mini Prototype Page Layout */}
-      <div className="bg-white border border-neutral-200 rounded-xl shadow-2xl overflow-hidden" style={{ height: '550px' }}>
+      <div className="bg-white border border-gray-200 rounded-xl shadow-2xl overflow-hidden h-[650px] lg:h-[550px]">
 
         {/* Mini Header */}
-        <div className="h-12 bg-white border-b border-neutral-200 flex items-center justify-between px-4">
+        <div className="h-12 bg-white border-b border-gray-200 flex items-center justify-between px-4">
           <div className="flex items-center space-x-3">
-            <div className="w-2 h-2 rounded-full bg-neutral-400"></div>
-            <span className="text-sm font-medium text-neutral-600">Task Card Demo</span>
+            <div className="w-2 h-2 rounded-full bg-gray-400"></div>
+            <span className="text-sm font-medium text-gray-600">Task Card Demo</span>
           </div>
           <div className="flex items-center space-x-2">
-            <div className="px-3 py-1 bg-neutral-100 rounded-md text-xs text-neutral-600 font-medium">
+            <div className="px-3 py-1 bg-gray-100 rounded-md text-xs text-gray-600 font-medium">
               Desktop
             </div>
           </div>
         </div>
 
         {/* Main Layout: Command Panel + Preview */}
-        <div className="flex h-[calc(100%-3rem)]">
+        <div className="flex flex-col lg:flex-row w-full h-[calc(100%-3rem)]">
 
           {/* Command Panel (Left Side) - mimics real CommandPanel */}
-          <div className="w-72 border-r border-neutral-200 bg-neutral-50/50 flex flex-col">
+          <div className="w-full lg:w-60 lg:shrink-0 border-b lg:border-b-0 lg:border-r border-gray-200 bg-gray-50/50 flex flex-col max-h-[280px] lg:max-h-none">
 
             {/* Output Messages */}
             <div className="flex-1 overflow-y-auto p-4 space-y-3">
@@ -145,29 +145,29 @@ export default function DemoCreationFlow({ onComplete }: DemoCreationFlowProps) 
                   }}
                 >
                   {message.type === 'user' && (
-                    <div className="bg-white border border-neutral-200 rounded-lg p-3 shadow-sm">
-                      <div className="text-xs text-neutral-500 font-medium mb-1.5">You</div>
-                      <div className="text-sm text-neutral-900">{message.text}</div>
+                    <div className="bg-white border border-gray-200 rounded-lg p-3 shadow-sm">
+                      <div className="text-xs text-gray-500 font-medium mb-1.5">You</div>
+                      <div className="text-sm text-gray-900">{message.text}</div>
                     </div>
                   )}
 
                   {message.type === 'assistant' && (
-                    <div className="bg-neutral-50 border border-neutral-200 rounded-lg p-3">
-                      <div className="text-xs text-neutral-500 font-medium mb-1.5">Agent</div>
-                      <div className="text-sm text-neutral-700">{message.text}</div>
+                    <div className="bg-gray-50 border border-gray-200 rounded-lg p-3">
+                      <div className="text-xs text-gray-500 font-medium mb-1.5">Agent</div>
+                      <div className="text-sm text-gray-700">{message.text}</div>
                     </div>
                   )}
 
                   {message.type === 'tool' && (
-                    <div className="flex items-center space-x-2 text-sm text-neutral-400 pl-3">
+                    <div className="flex items-center space-x-2 text-sm text-gray-400 pl-3">
                       <span className="opacity-60">{message.icon}</span>
                       <span>{message.text}</span>
                     </div>
                   )}
 
                   {message.type === 'success' && (
-                    <div className="bg-neutral-50 border border-neutral-200 rounded-lg p-3">
-                      <div className="text-sm text-neutral-700 font-medium">
+                    <div className="bg-gray-50 border border-gray-200 rounded-lg p-3">
+                      <div className="text-sm text-gray-700 font-medium">
                         {message.text}
                       </div>
                     </div>
@@ -176,69 +176,70 @@ export default function DemoCreationFlow({ onComplete }: DemoCreationFlowProps) 
               ))}
 
               {isPlaying && visibleMessages.length > 0 && (
-                <div className="flex items-center space-x-2 text-neutral-400 text-sm pl-3">
-                  <div className="w-1.5 h-1.5 bg-neutral-400 rounded-full animate-pulse"></div>
+                <div className="flex items-center space-x-2 text-gray-400 text-sm pl-3">
+                  <div className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-pulse"></div>
                   <span>Generating...</span>
                 </div>
               )}
             </div>
 
             {/* Command Input (Bottom) */}
-            <div className="border-t border-neutral-200 bg-white p-3">
-              <div className="flex items-center space-x-2 px-3 py-2 bg-neutral-100 rounded-lg text-sm text-neutral-400">
+            <div className="border-t border-gray-200 bg-white p-3">
+              <div className="flex items-center space-x-2 px-3 py-2 bg-gray-100 rounded-lg text-sm text-gray-400">
                 <span>Type a command...</span>
               </div>
             </div>
           </div>
 
           {/* Prototype Preview (Right Side) */}
-          <div className="flex-1 bg-neutral-50 flex items-center justify-center p-4">
+          <div className="flex-1 w-full bg-gray-100 flex items-center justify-center p-4 min-h-[300px]">
             <div
-              className={`w-full max-w-sm transition-all duration-700 ${
+              className={`w-full max-w-[240px] transition-all duration-700 ${
                 showResult ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
               }`}
             >
               {showResult ? (
-                <div className="border border-neutral-200 rounded-xl bg-white shadow-xl overflow-hidden">
-                  {/* Task Card Example */}
-                  <div className="p-6 space-y-4">
-                    <div className="flex items-start justify-between">
-                      <div className="space-y-3 flex-1">
-                        <div className="flex items-center space-x-2">
-                          <span className="px-2.5 py-1 bg-red-100 text-red-700 text-xs font-semibold rounded-full">
-                            High Priority
-                          </span>
-                          <span className="px-2.5 py-1 bg-blue-100 text-blue-700 text-xs font-semibold rounded-full">
-                            Design
-                          </span>
-                        </div>
-                        <h4 className="text-lg font-semibold text-neutral-900">
-                          Update landing page hero
-                        </h4>
-                        <p className="text-neutral-600 text-sm leading-relaxed">
-                          Revise the main headline and add a compelling demo section to showcase the product in action.
-                        </p>
-                      </div>
+                <div className="border border-gray-200 rounded-xl bg-white shadow-xl">
+                  <div className="p-6">
+                    {/* Badges */}
+                    <div className="flex flex-wrap items-center gap-2 mb-3">
+                      <span className="px-2.5 py-1 bg-red-100 text-red-700 text-xs font-semibold rounded-full">
+                        High Priority
+                      </span>
+                      <span className="px-2.5 py-1 bg-blue-100 text-blue-700 text-xs font-semibold rounded-full">
+                        Design
+                      </span>
                     </div>
 
-                    <div className="flex items-center justify-between pt-3 border-t border-neutral-100">
-                      <div className="flex items-center space-x-2 text-sm text-neutral-500">
+                    {/* Title */}
+                    <h4 className="text-lg font-semibold text-gray-900 mb-2">
+                      Update landing page hero
+                    </h4>
+
+                    {/* Description */}
+                    <p className="text-gray-600 text-sm leading-relaxed mb-4">
+                      Revise the main headline and add a compelling demo section to showcase the product in action.
+                    </p>
+
+                    {/* Footer */}
+                    <div className="flex items-center justify-between pt-4 border-t border-gray-100">
+                      <div className="flex items-center gap-2 text-sm text-gray-500">
                         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                         </svg>
                         <span>Due in 3 days</span>
                       </div>
-                      <button className="px-4 py-2 bg-neutral-900 text-white text-sm font-medium rounded-lg hover:bg-neutral-800 transition-colors">
+                      <button className="px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 transition-colors">
                         View Details
                       </button>
                     </div>
                   </div>
                 </div>
               ) : (
-                <div className="border border-neutral-200 rounded-xl bg-white shadow-lg p-8 flex items-center justify-center">
+                <div className="border border-gray-200 rounded-xl bg-white shadow-lg p-8 flex items-center justify-center">
                   <div className="text-center space-y-3">
-                    <div className="w-8 h-8 border-2 border-neutral-300 border-t-neutral-600 rounded-full animate-spin mx-auto"></div>
-                    <p className="text-sm text-neutral-500">Building prototype...</p>
+                    <div className="w-8 h-8 border-2 border-gray-300 border-t-gray-600 rounded-full animate-spin mx-auto"></div>
+                    <p className="text-sm text-gray-500">Building prototype...</p>
                   </div>
                 </div>
               )}

--- a/thoughts/shared/plans/2025-12-29-mobile-vignette-improvements.md
+++ b/thoughts/shared/plans/2025-12-29-mobile-vignette-improvements.md
@@ -1,0 +1,860 @@
+# Mobile Vignette Improvements Implementation Plan
+
+## Overview
+
+Fix six mobile responsiveness issues across the vignette components to achieve parity with the polished desktop experience. All fixes use existing Tailwind patterns and Framer Motion primitives already in the codebase.
+
+## Current State Analysis
+
+The vignettes were designed desktop-first and have several mobile breakages:
+- Fixed pixel widths that overflow narrow viewports
+- Horizontal layouts that don't stack
+- Absolute positioning that causes overlap
+- Missing touch gestures on the bottom sheet
+
+### Key Discoveries:
+- Codebase uses CSS-only responsive approach via Tailwind (`sm:`, `lg:` prefixes)
+- No `useMediaQuery` hook exists - all detection is CSS-based
+- `MobileDesignNotesSheet` already has spring animations (`damping: 25, stiffness: 300`)
+- `VignetteSplit` shows the responsive pattern: `grid-cols-1 lg:grid-cols-[360px_1fr]`
+
+## Desired End State
+
+All vignettes render correctly on mobile viewports (375px+):
+- No horizontal overflow or clipping
+- Touch-friendly interactions with swipe-to-dismiss on bottom sheet
+- Layouts stack appropriately on narrow screens
+- Primary CTAs remain visible and accessible
+
+## What We're NOT Doing
+
+- Adding a `useMediaQuery` JavaScript hook (CSS-only approach is sufficient)
+- Introducing new dependencies (no react-modal-sheet)
+- Creating separate mobile component trees
+- Adding tablet-specific breakpoints (out of scope for this pass)
+
+## Implementation Approach
+
+These fixes touch separate files and can be **executed in parallel** using subagents. Each agent works on one file to avoid conflicts.
+
+### Parallelization Strategy
+
+Spawn **5 parallel agents**, one per file:
+
+| Agent | File | Work |
+|-------|------|------|
+| A | `RichTextEditor.tsx` | Phase 1: Hide formatting buttons on mobile |
+| B | `HighlightsPanel.tsx` | Phase 2 + 5a: Fix loading skeleton + scattered cards |
+| C | `DemoCreationFlow.tsx` | Phase 3: Stack layout on mobile |
+| D | `SandboxPanel.tsx` | Phase 4 + 5b: Responsive TUI + scattered cards |
+| E | `MobileDesignNotesSheet.tsx` | Phase 6: Add swipe gestures |
+
+### Execution Instructions
+
+Use the Task tool to spawn all 5 agents in a single message:
+
+```
+<Task subagent_type="general-purpose" description="Fix RichTextEditor mobile">
+  Read and implement Phase 1 from thoughts/shared/plans/2025-12-29-mobile-vignette-improvements.md
+  File: src/components/demos/RichTextEditor.tsx
+  Task: Hide formatting buttons on mobile, keep Improve button visible
+</Task>
+
+<Task subagent_type="general-purpose" description="Fix HighlightsPanel mobile">
+  Read and implement Phase 2 AND the HighlightsPanel portion of Phase 5 from
+  thoughts/shared/plans/2025-12-29-mobile-vignette-improvements.md
+  File: src/components/vignettes/ai-highlights/HighlightsPanel.tsx
+  Tasks:
+  - Fix loading skeleton overflow (responsive widths, smaller gaps)
+  - Fix ProblemState scattered cards (stack on mobile, scatter on desktop)
+</Task>
+
+<Task subagent_type="general-purpose" description="Fix DemoCreationFlow mobile">
+  Read and implement Phase 3 from thoughts/shared/plans/2025-12-29-mobile-vignette-improvements.md
+  File: src/components/vignettes/vibe-coding/DemoCreationFlow.tsx
+  Task: Stack command panel above preview on mobile
+</Task>
+
+<Task subagent_type="general-purpose" description="Fix SandboxPanel mobile">
+  Read and implement Phase 4 AND the SandboxPanel portion of Phase 5 from
+  thoughts/shared/plans/2025-12-29-mobile-vignette-improvements.md
+  File: src/components/vignettes/prototyping/SandboxPanel.tsx
+  Tasks:
+  - Make TUI overlay responsive (w-full sm:w-[340px] lg:w-[420px])
+  - Fix ProblemState scattered cards (stack on mobile, scatter on desktop)
+</Task>
+
+<Task subagent_type="general-purpose" description="Add swipe to bottom sheet">
+  Read and implement Phase 6 from thoughts/shared/plans/2025-12-29-mobile-vignette-improvements.md
+  File: src/components/vignettes/shared/MobileDesignNotesSheet.tsx
+  Task: Add drag="y" swipe-to-dismiss gesture with Framer Motion
+</Task>
+```
+
+### After Parallel Execution
+
+Once all agents complete:
+1. Run `npm run build` to verify TypeScript compiles
+2. Run `npm run lint` to check for issues
+3. Perform manual testing on mobile viewport
+
+---
+
+## Phase 1: Fix RichTextEditor Toolbar
+
+### Overview
+The "Improve" button clips off-screen on mobile because the toolbar doesn't wrap. Hide the decorative formatting buttons on mobile to give the primary CTA room.
+
+### Changes Required:
+
+#### 1. RichTextEditor Component
+**File**: `src/components/demos/RichTextEditor.tsx`
+**Lines**: 30-51
+
+Wrap the formatting buttons in a container that hides on mobile:
+
+```tsx
+{/* Toolbar */}
+<div className="bg-white flex items-center gap-1.5 p-1.5">
+  {/* Hide formatting buttons on mobile - they're decorative in this demo */}
+  <div className="hidden sm:flex items-center gap-1.5">
+    {/* Text formatting */}
+    <button className="bg-white hover:bg-gray-50 p-3.5 rounded-lg size-12 flex items-center justify-center transition-colors">
+      <span className="material-icons-outlined text-h3 text-primary">format_bold</span>
+    </button>
+    <button className="bg-white hover:bg-gray-50 p-3.5 rounded-lg size-12 flex items-center justify-center transition-colors">
+      <span className="material-icons-outlined text-h3 text-primary">format_italic</span>
+    </button>
+    <button className="bg-white hover:bg-gray-50 p-3.5 rounded-lg size-12 flex items-center justify-center transition-colors">
+      <span className="material-icons-outlined text-h3 text-primary">format_underlined</span>
+    </button>
+
+    {/* Divider */}
+    <div className="h-12 w-px bg-[rgba(82,78,86,0.1)] mx-0.5" />
+
+    {/* List button */}
+    <button className="bg-white hover:bg-gray-50 p-3.5 rounded-lg size-12 flex items-center justify-center transition-colors">
+      <span className="material-icons-outlined text-h3 text-primary">format_list_bulleted</span>
+    </button>
+
+    {/* Divider */}
+    <div className="h-12 w-px bg-[rgba(82,78,86,0.1)] mx-0.5" />
+  </div>
+
+  {/* Improve button - always visible */}
+  {showImproveButton && (
+    // ... existing improve button code unchanged
+  )}
+</div>
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] TypeScript compiles: `npm run build`
+- [x] Linting passes: `npm run lint`
+
+#### Manual Verification:
+- [ ] On mobile (375px): Only "Improve" button visible in toolbar, no clipping
+- [ ] On desktop (1024px+): All formatting buttons visible
+- [ ] "Improve" button remains fully clickable and triggers the AI suggestions flow
+
+---
+
+## Phase 2: Fix Loading State Overflow
+
+### Overview
+The skeleton loading state in HighlightsPanel has fixed pixel widths and large gaps that cause horizontal overflow on mobile.
+
+### Changes Required:
+
+#### 1. HighlightsPanel LoadingState
+**File**: `src/components/vignettes/ai-highlights/HighlightsPanel.tsx`
+**Lines**: 156-177
+
+Make skeleton items responsive:
+
+```tsx
+{/* Skeleton Items */}
+{[0, 1, 2].map((index) => (
+  <div
+    key={index}
+    className={`px-6 py-8 ${index < 2 ? 'border-b-2 border-[#eaeaec]' : ''}`}
+  >
+    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+      <div className="flex-1 space-y-2">
+        <div className="flex items-center gap-1">
+          <div className="skeleton-bar w-5 h-5 rounded-full" />
+          <div className="skeleton-bar h-[15px] w-20 sm:w-[85px] rounded-[7px]" />
+        </div>
+        <div className="skeleton-bar h-[15px] w-full max-w-[240px] rounded-[7px]" />
+      </div>
+      <div className="flex items-center gap-4 sm:gap-12">
+        <div className="flex items-center gap-1">
+          <div className="skeleton-bar w-5 h-5 rounded-full" />
+          <div className="skeleton-bar h-[15px] w-14 sm:w-[60px] rounded-[7px]" />
+        </div>
+        <div className="skeleton-bar w-5 h-5 rounded-full" />
+      </div>
+    </div>
+  </div>
+))}
+```
+
+Key changes:
+- `flex-col sm:flex-row` - Stack on mobile, row on desktop
+- `gap-4 sm:gap-12` - Smaller gap on mobile
+- `w-full max-w-[240px]` - Fluid width with max constraint
+- `w-20 sm:w-[85px]` - Responsive fixed widths
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] TypeScript compiles: `npm run build`
+- [x] Linting passes: `npm run lint`
+
+#### Manual Verification:
+- [ ] On mobile (375px): Loading skeleton fits within container, no horizontal scroll
+- [ ] On desktop: Loading skeleton maintains current layout
+- [ ] Skeleton animation still runs smoothly
+
+---
+
+## Phase 3: Fix Vibe Coding Preview Visibility
+
+### Overview
+The DemoCreationFlow uses a horizontal flex layout with a fixed `w-72` (288px) command panel, leaving no room for the preview on mobile. Stack the layout vertically on mobile.
+
+### Changes Required:
+
+#### 1. DemoCreationFlow Component
+**File**: `src/components/vignettes/vibe-coding/DemoCreationFlow.tsx`
+**Lines**: 104-247
+
+Make the layout responsive:
+
+```tsx
+{/* Mini Prototype Page Layout */}
+<div className="bg-white border border-neutral-200 rounded-xl shadow-2xl overflow-hidden min-h-[550px] sm:h-[550px]">
+
+  {/* Mini Header - unchanged */}
+  <div className="h-12 bg-white border-b border-neutral-200 flex items-center justify-between px-4">
+    {/* ... existing header code ... */}
+  </div>
+
+  {/* Main Layout: Stack on mobile, side-by-side on desktop */}
+  <div className="flex flex-col sm:flex-row h-[calc(100%-3rem)]">
+
+    {/* Command Panel - full width on mobile, fixed width on desktop */}
+    <div className="w-full sm:w-72 border-b sm:border-b-0 sm:border-r border-neutral-200 bg-neutral-50/50 flex flex-col max-h-[280px] sm:max-h-none">
+      {/* ... existing command panel content ... */}
+    </div>
+
+    {/* Prototype Preview - full width on both */}
+    <div className="flex-1 bg-neutral-50 flex items-center justify-center p-4 min-h-[300px]">
+      {/* ... existing preview content ... */}
+    </div>
+  </div>
+</div>
+```
+
+Key changes:
+- `flex-col sm:flex-row` - Stack vertically on mobile
+- `w-full sm:w-72` - Full width on mobile, fixed on desktop
+- `border-b sm:border-b-0 sm:border-r` - Bottom border on mobile, right border on desktop
+- `max-h-[280px] sm:max-h-none` - Constrain command panel height on mobile
+- `min-h-[550px] sm:h-[550px]` - Min height on mobile, fixed on desktop
+- `min-h-[300px]` on preview - Ensure preview has space
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] TypeScript compiles: `npm run build`
+- [x] Linting passes: `npm run lint`
+
+#### Manual Verification:
+- [ ] On mobile (375px): Command panel stacks above preview, both visible
+- [ ] On mobile: Demo plays correctly with messages appearing
+- [ ] On mobile: Preview card visible after demo completes
+- [ ] On desktop: Side-by-side layout preserved
+- [ ] Replay button works on both mobile and desktop
+
+---
+
+## Phase 4: Make TUI Overlay Responsive
+
+### Overview
+The Claude Code TUI overlay in SandboxPanel has a fixed `w-[420px]` that clips on mobile. Scale it down responsively and adjust positioning.
+
+### Changes Required:
+
+#### 1. SandboxPanel SolutionState
+**File**: `src/components/vignettes/prototyping/SandboxPanel.tsx`
+**Lines**: 177-239
+
+Make the TUI overlay responsive:
+
+```tsx
+{/* Claude Code TUI Overlay */}
+<motion.div
+  initial={{ opacity: 0, y: 10, scale: 0.95 }}
+  animate={{ opacity: 1, y: 0, scale: 1 }}
+  transition={{ duration: 0.3, ease: 'easeOut', delay: 0.2 }}
+  className="absolute bottom-0 right-0 left-0 sm:left-auto bg-[#09090B] rounded-lg w-full sm:w-[340px] lg:w-[420px] shadow-2xl border border-[#1f1f23] overflow-hidden"
+  style={{ transform: 'translate(0, 50%)' }}
+>
+```
+
+Also make the prototype grid responsive (line 165):
+
+```tsx
+{/* Prototype Grid */}
+<div className="grid grid-cols-2 sm:grid-cols-3 gap-2 sm:gap-lg">
+  {content.prototypes.map((item) => (
+    <div
+      key={item.id}
+      className="rounded-[7px] h-[60px] sm:h-[78px]"
+      style={{ backgroundColor: item.thumbnail }}
+      aria-label={item.name}
+    />
+  ))}
+</div>
+```
+
+Key changes:
+- `left-0 sm:left-auto` - Full width on mobile, right-aligned on desktop
+- `w-full sm:w-[340px] lg:w-[420px]` - Responsive width scaling
+- `grid-cols-2 sm:grid-cols-3` - 2 columns on mobile, 3 on desktop
+- `h-[60px] sm:h-[78px]` - Smaller thumbnails on mobile
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] TypeScript compiles: `npm run build`
+- [x] Linting passes: `npm run lint`
+
+#### Manual Verification:
+- [ ] On mobile (375px): TUI overlay fits within viewport, no horizontal scroll
+- [ ] On mobile: Overlay text readable, not clipped
+- [ ] On tablet (640px): TUI at 340px width
+- [ ] On desktop (1024px+): TUI at full 420px width
+- [ ] Prototype grid shows 2 columns on mobile, 3 on desktop
+
+---
+
+## Phase 5: Fix Scattered Card Layouts
+
+### Overview
+Both HighlightsPanel and SandboxPanel use absolute positioning with percentages for "scattered" cards, causing overlap on narrow screens. Stack cards on mobile, scatter on desktop.
+
+### Changes Required:
+
+#### 1. HighlightsPanel ProblemState
+**File**: `src/components/vignettes/ai-highlights/HighlightsPanel.tsx`
+**Lines**: 194-261
+
+Replace the scattered layout with a responsive approach:
+
+```tsx
+function ProblemState({ cards, onTransition }: { cards: FeedbackSource[]; onTransition?: () => void }) {
+  const { entranceDelay, stagger } = useVignetteEntrance();
+  const displayCards = cards.slice(0, 5);
+  const ctaDelay = entranceDelay + displayCards.length * stagger + 0.1;
+
+  return (
+    <div className="relative bg-gray-50 border-2 border-dashed border-gray-300 rounded-lg min-h-[300px] lg:min-h-[400px] flex flex-col items-center justify-end p-4 lg:p-8 overflow-hidden">
+      {/* Mobile: stacked cards, Desktop: scattered absolute */}
+      <div className="w-full lg:absolute lg:inset-0 flex flex-col gap-3 lg:block mb-4 lg:mb-0">
+        {displayCards.map((card, index) => {
+          const pos = feedbackCardPositions[index % feedbackCardPositions.length];
+          return (
+            <motion.div
+              key={card.id}
+              className="bg-white px-4 py-3 rounded-lg shadow-sm border border-gray-200 lg:absolute lg:max-w-[220px]"
+              style={{
+                // Only apply absolute positioning on lg+ via CSS, but we need inline for the rotation
+              }}
+              // Use CSS for positioning, keep animation
+              initial={{ opacity: 0, y: 20, scale: 0.9 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              transition={{
+                duration: 0.4,
+                delay: entranceDelay + index * stagger,
+                ease: 'easeOut' as const,
+              }}
+            >
+              {/* Add a wrapper for desktop positioning */}
+              <style jsx>{`
+                @media (min-width: 1024px) {
+                  .card-${index} {
+                    position: absolute;
+                    top: ${pos.top};
+                    ${pos.left ? `left: ${pos.left};` : ''}
+                    ${pos.right ? `right: ${pos.right};` : ''}
+                    transform: rotate(${pos.rotate}deg);
+                  }
+                }
+              `}</style>
+              {card.from && (
+                <div className="flex items-center gap-2 mb-2">
+                  {card.avatarUrl && (
+                    <img
+                      src={card.avatarUrl}
+                      alt={card.from}
+                      className="w-6 h-6 rounded-full"
+                    />
+                  )}
+                  <span className="text-body-sm font-semibold text-primary">
+                    {card.from}
+                  </span>
+                </div>
+              )}
+              <p className="text-body-sm text-secondary line-clamp-3">
+                {card.content}
+              </p>
+            </motion.div>
+          );
+        })}
+      </div>
+
+      {/* CTA */}
+      <motion.button
+        onClick={onTransition}
+        className="btn-interactive btn-primary relative z-10"
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: ctaDelay, duration: 0.3 }}
+      >
+        <span className="material-icons-outlined">auto_awesome</span>
+        Show Highlights and Opportunities
+      </motion.button>
+    </div>
+  );
+}
+```
+
+**Alternative simpler approach** - conditionally render different layouts:
+
+```tsx
+function ProblemState({ cards, onTransition }: { cards: FeedbackSource[]; onTransition?: () => void }) {
+  const { entranceDelay, stagger } = useVignetteEntrance();
+  const displayCards = cards.slice(0, 5);
+  const ctaDelay = entranceDelay + displayCards.length * stagger + 0.1;
+
+  return (
+    <div className="relative bg-gray-50 border-2 border-dashed border-gray-300 rounded-lg min-h-[300px] lg:min-h-[400px] flex flex-col items-center justify-end p-4 lg:p-8 overflow-hidden">
+      {/* Mobile: Simple stacked layout */}
+      <div className="flex flex-col gap-3 w-full mb-4 lg:hidden">
+        {displayCards.slice(0, 3).map((card, index) => (
+          <motion.div
+            key={card.id}
+            className="bg-white px-4 py-3 rounded-lg shadow-sm border border-gray-200"
+            initial={{ opacity: 0, y: 20, scale: 0.9 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            transition={{
+              duration: 0.4,
+              delay: entranceDelay + index * stagger,
+              ease: 'easeOut' as const,
+            }}
+          >
+            {card.from && (
+              <div className="flex items-center gap-2 mb-2">
+                {card.avatarUrl && (
+                  <img src={card.avatarUrl} alt={card.from} className="w-6 h-6 rounded-full" />
+                )}
+                <span className="text-body-sm font-semibold text-primary">{card.from}</span>
+              </div>
+            )}
+            <p className="text-body-sm text-secondary line-clamp-2">{card.content}</p>
+          </motion.div>
+        ))}
+      </div>
+
+      {/* Desktop: Scattered absolute positioning */}
+      <div className="absolute inset-0 hidden lg:block">
+        {displayCards.map((card, index) => {
+          const pos = feedbackCardPositions[index % feedbackCardPositions.length];
+          return (
+            <motion.div
+              key={card.id}
+              className="absolute bg-white px-4 py-3 rounded-lg shadow-sm border border-gray-200 max-w-[220px]"
+              style={{
+                top: pos.top,
+                left: pos.left,
+                right: pos.right,
+                transform: `rotate(${pos.rotate}deg)`,
+              }}
+              initial={{ opacity: 0, y: 20, scale: 0.9 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              transition={{
+                duration: 0.4,
+                delay: entranceDelay + index * stagger,
+                ease: 'easeOut' as const,
+              }}
+            >
+              {card.from && (
+                <div className="flex items-center gap-2 mb-2">
+                  {card.avatarUrl && (
+                    <img src={card.avatarUrl} alt={card.from} className="w-6 h-6 rounded-full" />
+                  )}
+                  <span className="text-body-sm font-semibold text-primary">{card.from}</span>
+                </div>
+              )}
+              <p className="text-body-sm text-secondary line-clamp-3">{card.content}</p>
+            </motion.div>
+          );
+        })}
+      </div>
+
+      {/* CTA */}
+      <motion.button
+        onClick={onTransition}
+        className="btn-interactive btn-primary relative z-10"
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: ctaDelay, duration: 0.3 }}
+      >
+        <span className="material-icons-outlined">auto_awesome</span>
+        Show Highlights and Opportunities
+      </motion.button>
+    </div>
+  );
+}
+```
+
+#### 2. SandboxPanel ProblemState
+**File**: `src/components/vignettes/prototyping/SandboxPanel.tsx`
+**Lines**: 16-81
+
+Apply the same pattern:
+
+```tsx
+function ProblemState({
+  questions,
+  onTransition
+}: {
+  questions: PrototypingContent['problemQuestions'];
+  onTransition?: () => void;
+}) {
+  const { entranceDelay, stagger } = useVignetteEntrance();
+  const ctaDelay = entranceDelay + questions.length * stagger + 0.1;
+
+  return (
+    <div className="relative bg-gray-50 border-2 border-dashed border-gray-300 rounded-lg min-h-[280px] lg:min-h-[320px] flex flex-col items-center justify-center p-4 lg:p-8">
+      {/* Mobile: Stacked questions */}
+      <div className="flex flex-col gap-2 w-full mb-4 lg:hidden">
+        {questions.map((q, index) => (
+          <motion.div
+            key={q.id}
+            className="bg-white px-4 py-2 rounded-lg shadow-sm border border-gray-200 text-body-sm text-gray-600 font-medium"
+            initial={{ opacity: 0, y: 20, scale: 0.9 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            transition={{
+              duration: 0.4,
+              delay: entranceDelay + index * stagger,
+              ease: 'easeOut' as const,
+            }}
+          >
+            {q.text}
+          </motion.div>
+        ))}
+      </div>
+
+      {/* Desktop: Scattered floating questions */}
+      <div className="relative w-full h-36 hidden lg:block">
+        {questions.map((q, index) => {
+          const positions = [
+            { top: '10%', left: '5%', rotate: -5 },
+            { top: '5%', right: '10%', rotate: 3 },
+            { top: '45%', left: '15%', rotate: -2 },
+            { top: '55%', right: '5%', rotate: 4 },
+          ];
+          const pos = positions[index % positions.length];
+
+          return (
+            <motion.div
+              key={q.id}
+              className="absolute bg-white px-4 py-2 rounded-lg shadow-sm border border-gray-200 text-body-sm text-gray-600 font-medium"
+              style={{
+                ...pos,
+                transform: `rotate(${pos.rotate}deg)`,
+              }}
+              initial={{ opacity: 0, y: 20, scale: 0.9 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              transition={{
+                duration: 0.4,
+                delay: entranceDelay + index * stagger,
+                ease: 'easeOut' as const,
+              }}
+            >
+              {q.text}
+            </motion.div>
+          );
+        })}
+      </div>
+
+      {/* CTA */}
+      <motion.button
+        onClick={onTransition}
+        className="btn-interactive btn-primary mt-4 lg:mt-6"
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: ctaDelay, duration: 0.3 }}
+      >
+        <span className="material-icons-outlined">auto_awesome</span>
+        See how I enabled this
+      </motion.button>
+    </div>
+  );
+}
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] TypeScript compiles: `npm run build`
+- [x] Linting passes: `npm run lint`
+
+#### Manual Verification:
+- [ ] On mobile (375px): Cards stack vertically, no overlap, all readable
+- [ ] On mobile: CTA button visible and clickable
+- [ ] On desktop (1024px+): Cards scattered with rotation, matching current design
+- [ ] Animations play correctly on both layouts
+- [ ] Both HighlightsPanel and SandboxPanel behave consistently
+
+---
+
+## Phase 6: Add Swipe Gestures to Bottom Sheet
+
+### Overview
+Add drag-to-dismiss gesture to MobileDesignNotesSheet using Framer Motion's drag API. This brings the sheet to iOS-level polish.
+
+### Changes Required:
+
+#### 1. MobileDesignNotesSheet Component
+**File**: `src/components/vignettes/shared/MobileDesignNotesSheet.tsx`
+**Lines**: 62-137
+
+Add drag gesture support:
+
+```tsx
+import { useEffect, useState } from 'react';
+import { motion, AnimatePresence, PanInfo } from 'framer-motion';
+import type { DesignNote } from '@/components/vignettes/types';
+
+interface MobileDesignNotesSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  notes: DesignNote[];
+  currentIndex: number;
+  onIndexChange: (index: number) => void;
+}
+
+export function MobileDesignNotesSheet({
+  isOpen,
+  onClose,
+  notes,
+  currentIndex,
+  onIndexChange,
+}: MobileDesignNotesSheetProps) {
+  const currentNote = notes[currentIndex];
+  const [isDragging, setIsDragging] = useState(false);
+
+  // Keyboard navigation (unchanged)
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case 'Escape':
+          onClose();
+          break;
+        case 'ArrowRight':
+          if (currentIndex < notes.length - 1) onIndexChange(currentIndex + 1);
+          break;
+        case 'ArrowLeft':
+          if (currentIndex > 0) onIndexChange(currentIndex - 1);
+          break;
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, currentIndex, notes.length, onClose, onIndexChange]);
+
+  // Handle drag end - dismiss if dragged down past threshold
+  const handleDragEnd = (_: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
+    setIsDragging(false);
+    // Dismiss if dragged down more than 100px or with high velocity
+    if (info.offset.y > 100 || info.velocity.y > 500) {
+      onClose();
+    }
+  };
+
+  if (!currentNote) return null;
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <>
+          {/* Backdrop */}
+          <motion.div
+            className="fixed inset-0 bg-black/20 z-40 lg:hidden"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onClose}
+          />
+
+          {/* Sheet with drag support */}
+          <motion.div
+            className="fixed inset-x-0 bottom-0 bg-white rounded-t-2xl z-50 lg:hidden shadow-xl touch-none"
+            initial={{ y: '100%' }}
+            animate={{ y: 0 }}
+            exit={{ y: '100%' }}
+            transition={{ type: 'spring', damping: 25, stiffness: 300 }}
+            drag="y"
+            dragConstraints={{ top: 0, bottom: 0 }}
+            dragElastic={{ top: 0, bottom: 0.6 }}
+            onDragStart={() => setIsDragging(true)}
+            onDragEnd={handleDragEnd}
+          >
+            {/* Drag Handle - visual indicator */}
+            <div className="flex justify-center pt-3 pb-2 cursor-grab active:cursor-grabbing">
+              <div className="w-10 h-1 bg-gray-300 rounded-full" />
+            </div>
+
+            {/* Progress dots */}
+            <div className="px-6 pb-3 flex items-center justify-between">
+              <span className="text-sm text-gray-500">
+                {currentIndex + 1} of {notes.length}
+              </span>
+              <div className="flex gap-1.5">
+                {notes.map((_, i) => (
+                  <button
+                    key={i}
+                    className={`w-2 h-2 rounded-full transition-colors ${
+                      i === currentIndex ? 'bg-gray-900' : 'bg-gray-300'
+                    }`}
+                    onClick={() => onIndexChange(i)}
+                    aria-label={`Go to note ${i + 1}`}
+                  />
+                ))}
+              </div>
+            </div>
+
+            {/* Content - disable transitions while dragging for performance */}
+            <div className="px-6 pb-6">
+              <AnimatePresence mode="wait">
+                <motion.div
+                  key={currentNote.id}
+                  initial={isDragging ? false : { opacity: 0, x: 20 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={isDragging ? false : { opacity: 0, x: -20 }}
+                  transition={{ duration: 0.15 }}
+                >
+                  {currentNote.label && (
+                    <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                      {currentNote.label}
+                    </h3>
+                  )}
+                  <p className="text-gray-600 leading-relaxed">
+                    {currentNote.detail}
+                  </p>
+                </motion.div>
+              </AnimatePresence>
+            </div>
+
+            {/* Navigation */}
+            <div className="px-6 pb-6 flex gap-3">
+              <button
+                className="flex-1 py-3 px-4 rounded-xl border border-gray-200 text-gray-700 font-medium disabled:opacity-40"
+                onClick={() => onIndexChange(currentIndex - 1)}
+                disabled={currentIndex === 0}
+              >
+                Previous
+              </button>
+              <button
+                className="flex-1 py-3 px-4 rounded-xl bg-gray-900 text-white font-medium"
+                onClick={() => {
+                  if (currentIndex === notes.length - 1) {
+                    onClose();
+                  } else {
+                    onIndexChange(currentIndex + 1);
+                  }
+                }}
+              >
+                {currentIndex === notes.length - 1 ? 'Done' : 'Next'}
+              </button>
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}
+```
+
+Key changes:
+- Added `drag="y"` for vertical dragging
+- Added `dragConstraints={{ top: 0, bottom: 0 }}` to prevent dragging up
+- Added `dragElastic={{ top: 0, bottom: 0.6 }}` for bounce effect when dragging down
+- Added `touch-none` class to prevent scroll interference
+- Added `onDragEnd` handler to dismiss when threshold exceeded
+- Added `cursor-grab` / `cursor-grabbing` on handle for desktop feedback
+- Added `isDragging` state to disable content transitions during drag
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] TypeScript compiles: `npm run build`
+- [x] Linting passes: `npm run lint`
+
+#### Manual Verification:
+- [ ] On mobile: Swipe down on sheet dismisses it
+- [ ] On mobile: Small swipe snaps back (doesn't dismiss)
+- [ ] On mobile: Fast swipe dismisses even if distance is short
+- [ ] On mobile: Swipe up is blocked (can't drag past top)
+- [ ] Drag handle shows grab cursor on desktop
+- [ ] Button navigation still works
+- [ ] Keyboard navigation (Escape, arrows) still works
+- [ ] No scroll interference when dragging sheet
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+- No new unit tests required - these are CSS/layout changes
+
+### Integration Tests:
+- No new integration tests required
+
+### Manual Testing Steps:
+1. Open site on mobile device or Chrome DevTools mobile emulator (375px width)
+2. For each vignette:
+   - AI Suggestions: Verify "Improve" button visible, not clipped
+   - AI Highlights: Verify loading skeleton fits, problem cards stack, solution readable
+   - Prototyping: Verify TUI overlay fits, problem questions stack
+   - Vibe Coding: Verify both command panel and preview visible
+3. Test bottom sheet:
+   - Open design notes on any vignette
+   - Swipe down to dismiss
+   - Verify snap-back on small swipe
+4. Resize browser from mobile to desktop:
+   - Verify smooth transition between layouts
+   - No layout jumps or broken states
+
+## Performance Considerations
+
+- Using CSS-only responsive approach avoids JavaScript resize listeners
+- `touch-none` on bottom sheet prevents passive scroll listener issues
+- Drag gestures use Framer Motion's optimized spring physics
+- No new dependencies added
+
+## References
+
+- Research document: `thoughts/shared/research/2025-12-29-mobile-vignette-patterns.md`
+- Existing responsive pattern: `src/components/vignettes/VignetteSplit.tsx:67`
+- Existing sheet animation: `src/components/vignettes/shared/MobileDesignNotesSheet.tsx:67`
+- Framer Motion drag docs: https://www.framer.com/motion/gestures/

--- a/thoughts/shared/research/2025-12-29-mobile-vignette-patterns.md
+++ b/thoughts/shared/research/2025-12-29-mobile-vignette-patterns.md
@@ -1,0 +1,273 @@
+---
+date: 2025-12-29T21:16:29+11:00
+git_commit: a533cdb0b5cad4dc248c336efcd19b617c0d26d3
+branch: mobile-improvements
+repository: mobile-improvements
+topic: "Improving mobile vignette experience to match desktop quality"
+tags: [research, ux-patterns, mobile, vignettes, responsive-design, bottom-sheet]
+status: complete
+last_updated: 2025-12-29
+last_updated_by: claude
+---
+
+# Research: Improving Mobile Vignette Experience
+
+The vignettes break on mobile in several key areas: scattered card layouts overlap, the TUI overlay clips off-screen, and the design notes system loses its spatial context. The goal is to make mobile feel as polished as desktop.
+
+## Recommendation
+
+Given your existing Framer Motion primitives and the fact that you already have a mobile bottom sheet pattern, I'd focus on four targeted fixes rather than a full mobile redesign:
+
+1. **Replace scattered absolute positioning with responsive stacked layouts on mobile** - use CSS Grid with `auto-fit` to gracefully collapse cards
+2. **Make the TUI overlay responsive** - either hide it on mobile or scale it to fit within bounds
+3. **Add swipe gestures to the bottom sheet** - you have Framer Motion, so adding `drag="y"` with snap points is ~2h of work and brings the sheet to iOS-level polish
+4. **Fix the RichTextEditor toolbar** - the "Improve" button clips on mobile; either hide the text label or collapse secondary formatting buttons
+
+This approach uses patterns already in your codebase and avoids introducing new dependencies.
+
+## Quick Comparison
+
+| Option | Effort | Uses Existing | Risk | Verdict |
+|--------|--------|---------------|------|---------|
+| A: Targeted fixes (responsive cards + swipe sheet) | 4-6h | Framer Motion, existing sheet | Low | **Recommended** |
+| B: Mobile-first rebuild with react-modal-sheet | 8-12h | New dependency | Medium | Consider if time allows |
+| C: Separate mobile components | 12-16h | New architecture | High | Skip - maintenance burden |
+
+## Constraints Considered
+
+- **Stack**: Next.js 16, React 19, Framer Motion 12, Tailwind CSS 4
+- **Existing patterns**: `MobileDesignNotesSheet` (bottom sheet), `VignetteSplit` (responsive grid), `useReducedMotion` hook
+- **Priority**: Polish and parity with desktop - the current mobile experience feels unfinished
+
+## Issues Identified
+
+### 1. Scattered Card Layouts Break on Mobile
+
+**File**: `src/components/vignettes/ai-highlights/HighlightsPanel.tsx:186-192`
+
+```tsx
+const feedbackCardPositions = [
+  { top: '5%', left: '5%', rotate: -4 },
+  { top: '8%', right: '8%', rotate: 3 },
+  // ...cards use absolute positioning with percentages
+];
+```
+
+On narrow screens, these cards overlap and become unreadable. Same issue in `SandboxPanel.tsx:34-39`.
+
+### 2. TUI Overlay Clips Off-Screen
+
+**File**: `src/components/vignettes/prototyping/SandboxPanel.tsx:182-184`
+
+```tsx
+className="absolute bottom-0 right-0 bg-[#09090B] rounded-lg w-[420px]"
+style={{ transform: 'translate(0, 50%)' }}
+```
+
+Fixed 420px width clips on mobile viewports. The overlay should either scale down or be hidden on small screens.
+
+### 3. Bottom Sheet Lacks Touch Gestures
+
+**File**: `src/components/vignettes/shared/MobileDesignNotesSheet.tsx`
+
+The sheet has keyboard navigation and button-based prev/next, but no swipe-to-dismiss or drag-to-snap - standard mobile expectations per [Apple HIG](https://developer.apple.com/design/human-interface-guidelines/modality) and [Mobbin patterns](https://mobbin.com/glossary/bottom-sheet).
+
+### 4. No Intermediate Tablet Breakpoint
+
+Layout jumps from fully stacked (mobile) to two-column (lg: 1024px). Tablets in the 768-1024px range get the mobile layout despite having room for more.
+
+### 5. RichTextEditor Toolbar Clips "Improve" Button on Mobile
+
+**File**: `src/components/demos/RichTextEditor.tsx:30-71`
+
+```tsx
+<div className="bg-white flex items-center gap-1.5 p-1.5">
+  {/* Text formatting buttons: Bold, Italic, Underline, List */}
+  {/* Dividers */}
+  {/* Improve button at end */}
+  <button className="btn-interactive btn-primary h-10 px-3 py-2">
+    <span className="material-icons-outlined">auto_awesome</span>
+    <span className="text-sm">Improve</span>
+  </button>
+</div>
+```
+
+The toolbar uses a horizontal `flex` layout with no wrapping or overflow handling. On narrow viewports, the "Improve" button at the end gets clipped. This is particularly visible in the AI Suggestions vignette where the button is the primary CTA.
+
+**Fix options:**
+1. **Collapse formatting buttons on mobile (recommended)**: Hide Bold/Italic/Underline/List on mobile since they're decorative in this demo - keeps the full "Improve" button visible as the hero CTA
+2. **Responsive toolbar**: Wrap or stack buttons on mobile using `flex-wrap` or switch to a 2-row layout
+3. **Horizontal scroll**: Add `overflow-x-auto` to allow swiping to reveal the button (not recommended - hidden affordance)
+4. ~~**Icon-only on mobile**~~: Loses the clarity of the "Improve" label which is central to the vignette's message
+
+---
+
+## Option A: Targeted Fixes (Recommended)
+
+### Why this works
+Addresses the three most visible issues without architectural changes. Uses existing Framer Motion patterns. Can be shipped incrementally.
+
+### Implementation sketch
+
+**Fix 1: Responsive scattered cards**
+
+```tsx
+// Replace absolute positioning with responsive grid on mobile
+function ProblemState({ cards }) {
+  return (
+    <div className="relative min-h-[400px] flex flex-col items-center justify-end p-8">
+      {/* Mobile: stacked cards, Desktop: scattered absolute */}
+      <div className="lg:absolute lg:inset-0 grid gap-3 lg:block mb-6 lg:mb-0">
+        {cards.map((card, index) => (
+          <motion.div
+            key={card.id}
+            className={`
+              bg-white px-4 py-3 rounded-lg shadow-sm border border-gray-200
+              lg:absolute lg:max-w-[220px]
+            `}
+            style={
+              // Only apply absolute positioning on desktop (via CSS or JS check)
+              isDesktop ? {
+                top: positions[index].top,
+                left: positions[index].left,
+                transform: `rotate(${positions[index].rotate}deg)`,
+              } : {}
+            }
+          >
+            {/* card content */}
+          </motion.div>
+        ))}
+      </div>
+      <button>CTA</button>
+    </div>
+  );
+}
+```
+
+Alternatively, use a `useMediaQuery` hook or Tailwind's responsive classes to conditionally render different layouts entirely.
+
+**Fix 2: Responsive TUI overlay**
+
+```tsx
+// Scale or hide on mobile
+<motion.div
+  className="
+    absolute bottom-0 right-0
+    w-[280px] sm:w-[340px] lg:w-[420px]
+    lg:translate-y-1/2
+    hidden sm:block  /* or scale it down */
+  "
+>
+```
+
+Or: create a condensed mobile version that shows a "Remix" button that opens a modal with the TUI content.
+
+**Fix 3: Swipe gestures for bottom sheet**
+
+```tsx
+// Add drag support to MobileDesignNotesSheet
+<motion.div
+  className="fixed inset-x-0 bottom-0 bg-white rounded-t-2xl z-50"
+  drag="y"
+  dragConstraints={{ top: 0, bottom: 0 }}
+  dragElastic={{ top: 0, bottom: 0.5 }}
+  onDragEnd={(_, info) => {
+    // Dismiss if dragged down past threshold
+    if (info.offset.y > 100 || info.velocity.y > 500) {
+      onClose();
+    }
+  }}
+  initial={{ y: '100%' }}
+  animate={{ y: 0 }}
+  exit={{ y: '100%' }}
+  transition={{ type: 'spring', damping: 25, stiffness: 300 }}
+>
+```
+
+This matches iOS sheet behavior and uses your existing Framer Motion setup.
+
+**Fix 4: Responsive RichTextEditor toolbar**
+
+```tsx
+// Collapse formatting buttons on mobile, keep full "Improve" button
+<div className="bg-white flex items-center gap-1.5 p-1.5">
+  {/* Hide decorative formatting buttons on mobile */}
+  <div className="hidden sm:flex items-center gap-1.5">
+    <button>Bold</button>
+    <button>Italic</button>
+    <button>Underline</button>
+    <div className="divider" />
+    <button>List</button>
+    <div className="divider" />
+  </div>
+  {/* Improve button always visible with full label */}
+  <button className="btn-interactive btn-primary h-10 px-3 py-2">
+    <span className="material-icons-outlined">auto_awesome</span>
+    <span className="text-sm">Improve</span>
+  </button>
+</div>
+```
+
+The formatting buttons are decorative in this demo context - hiding them on mobile keeps the "Improve" CTA front and center, which is the whole point of the vignette.
+
+### Similar to in codebase
+- `MobileDesignNotesSheet.tsx` already uses spring animations for the sheet
+- `VignetteSplit.tsx` shows the responsive grid pattern with `lg:grid-cols-[360px_1fr]`
+
+### Gotchas
+- `drag="y"` requires `touch-action: none` on the element to prevent scroll interference
+- Test on iOS Safari specifically - sheets can interact oddly with the browser chrome
+- Consider `useDragControls` if you want the drag handle to be the only draggable area
+
+---
+
+## Option B: react-modal-sheet Integration
+
+### Why consider this
+If you want production-ready sheet behavior without building it yourself, [react-modal-sheet](https://github.com/Temzasse/react-modal-sheet) provides snap points, keyboard avoidance, and accessibility out of the box.
+
+### Implementation sketch
+
+```tsx
+import Sheet from 'react-modal-sheet';
+
+function MobileDesignNotes({ isOpen, onClose, notes }) {
+  return (
+    <Sheet isOpen={isOpen} onClose={onClose} snapPoints={[400, 200, 0]}>
+      <Sheet.Container>
+        <Sheet.Header />
+        <Sheet.Content>
+          {/* Your existing note content */}
+        </Sheet.Content>
+      </Sheet.Container>
+      <Sheet.Backdrop />
+    </Sheet>
+  );
+}
+```
+
+### Gotchas
+- Adds ~15KB to bundle (gzipped)
+- Requires React 18+ (you have React 19, so fine)
+- Style customization uses CSS variables which may conflict with your Tailwind setup
+
+---
+
+## What I Ruled Out
+
+- **Separate mobile component tree**: Too much duplication and maintenance burden for a portfolio site
+- **CSS-only scattered card animation**: Can't replicate the staggered Framer Motion animations
+- **Vaul (Drawer)**: Similar to react-modal-sheet but less documented; your existing sheet is already close to feature parity
+- **Full page takeover on mobile**: Loses the "vignette" feel - they should remain embedded experiences
+
+---
+
+## Sources
+
+- [Mobbin Bottom Sheet UI Design](https://mobbin.com/glossary/bottom-sheet) - Best practices and 12,500+ real examples of bottom sheet patterns
+- [Apple HIG: Modality](https://developer.apple.com/design/human-interface-guidelines/modality) - Sheet behavior expectations for iOS users
+- [Framer Motion Gestures](https://www.framer.com/motion/gestures/) - `whileTap` as mobile fallback for `whileHover`, drag gesture implementation
+- [react-modal-sheet](https://github.com/Temzasse/react-modal-sheet) - Production-ready sheet library with Framer Motion
+- [CSS Grid Responsive Cards](https://css-tricks.com/look-ma-no-media-queries-responsive-layouts-using-css-grid/) - `auto-fit` + `minmax()` pattern for no-media-query responsiveness
+- [Mobile vs Desktop UI Design](https://medium.com/design-bootcamp/mobile-vs-desktop-ui-design-key-differences-and-best-practices-727bfe8f9461) - Touch target sizing (20-25% larger on mobile)
+- [Linear App](https://www.eleken.co/blog-posts/mobile-ux-design-examples) - Reference for tight transitions and focused mobile interactions


### PR DESCRIPTION
## Summary
- Fix mobile responsiveness across multiple vignette components (HighlightsPanel, ProblemPanel, SandboxPanel, RichTextEditor)
- Add mobile chat-to-preview transition in DemoCreationFlow for better UX on small screens
- Make vibe-coding demo self-referential by showing Claude building a portfolio vignette instead of a generic task card

## Test plan
- [ ] Test vignettes on mobile viewport sizes (375px, 390px, 414px)
- [ ] Verify DemoCreationFlow transitions smoothly from chat to preview on mobile
- [ ] Check that the mini vignette preview renders correctly in both desktop and mobile layouts
- [ ] Confirm design notes sheets work properly on touch devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)