### PR TITLE
Improve feedback card layout and visual polish in vignettes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -502,3 +502,8 @@ a {
     transform: none;
   }
 }
+
+/* Brand hover colors */
+.hover-linkedin:hover {
+  color: #0A66C2;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -125,11 +125,11 @@
   --text-h1--letter-spacing: -0.04em;
   --text-h1--font-weight: 700;
 
-  --text-h2: 1.75rem;
+  --text-h2: 2rem;
   --text-h2--line-height: 1.1;
   --text-h2--letter-spacing: -0.03em;
 
-  --text-h3: 1.125rem;
+  --text-h3: 1.5rem;
   --text-h3--line-height: 1.3;
 
   --text-body: 1.125rem;
@@ -196,7 +196,8 @@
 }
 
 .type-h3 {
-  @apply text-h3 font-semibold;
+  @apply text-h3 font-medium;
+  font-family: var(--font-display), system-ui, sans-serif;
   color: var(--primary);
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Inter, Space_Grotesk } from "next/font/google";
 import "./globals.css";
 import { Analytics } from "@vercel/analytics/next";
@@ -20,6 +20,11 @@ const spaceGrotesk = Space_Grotesk({
 export const metadata: Metadata = {
   title: "Idam Adam - Lead Product Designer",
   description: "Portfolio of Idam Adam, Lead Product Designer with 8 years of experience creating intuitive web and mobile products through user-centered design.",
+};
+
+export const viewport: Viewport = {
+  themeColor: "#FAFAFA",
+  viewportFit: "cover",
 };
 
 // Polyfill localStorage for SSR

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,12 +20,18 @@ export default function Home() {
 
         {/* Vignettes Section */}
         <section className="w-full pb-16 lg:pb-24 px-6 lg:px-12">
-          <div className="max-w-5xl mx-auto space-y-12 lg:space-y-14">
-            <AIHighlightsVignette />
+          <div className="max-w-6xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-10">
+            <div className="lg:col-span-2">
+              <AIHighlightsVignette />
+            </div>
             <AISuggestionsVignette />
             <PrototypingVignette />
-            <MultilingualVignette />
-            <HomeConnectVignette />
+            <div className="lg:col-span-2">
+              <MultilingualVignette />
+            </div>
+            <div className="lg:col-span-2">
+              <HomeConnectVignette />
+            </div>
           </div>
         </section>
 
@@ -39,7 +45,7 @@ export default function Home() {
 
         {/* Explorations Vignettes */}
         <section className="w-full pb-8 lg:pb-12 px-6 lg:px-12">
-          <div className="max-w-5xl mx-auto space-y-12 lg:space-y-14">
+          <div className="max-w-6xl mx-auto">
             <VibeCodingVignette />
           </div>
         </section>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -10,7 +10,7 @@ export default function Footer() {
 
   return (
     <footer className="w-full py-16 lg:py-20 px-6 lg:px-12">
-      <div className="max-w-5xl mx-auto border-t border-neutral-300 pt-10 lg:pt-12">
+      <div className="max-w-6xl mx-auto border-t border-neutral-300 pt-10 lg:pt-12">
         <motion.div
           className="flex flex-col items-center text-center gap-4"
           initial={{ opacity: 0, y: 30 }}

--- a/src/components/GrainBackground.tsx
+++ b/src/components/GrainBackground.tsx
@@ -9,7 +9,10 @@ export function GrainBackground() {
     <div
       style={{
         position: 'fixed',
-        inset: 0,
+        top: 'calc(-1 * env(safe-area-inset-top, 0px))',
+        right: 'calc(-1 * env(safe-area-inset-right, 0px))',
+        bottom: 'calc(-1 * env(safe-area-inset-bottom, 0px))',
+        left: 'calc(-1 * env(safe-area-inset-left, 0px))',
         zIndex: 0,
         pointerEvents: 'none',
       }}

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -42,7 +42,7 @@ export default function SectionHeader({ title, children }: SectionHeaderProps) {
 
   return (
     <section className="w-full pb-10 lg:pb-12 px-6 lg:px-12">
-      <div className="max-w-5xl mx-auto border-t border-border pt-10 lg:pt-12 space-y-3">
+      <div className="max-w-6xl mx-auto border-t border-border pt-10 lg:pt-12 space-y-3">
         <motion.h2
           className="type-h2"
           initial="hidden"

--- a/src/components/SectionTitle.tsx
+++ b/src/components/SectionTitle.tsx
@@ -14,7 +14,7 @@ export default function SectionTitle({ children }: SectionTitleProps) {
 
   return (
     <section className="w-full pb-10 lg:pb-12 px-6 lg:px-12">
-      <div className="max-w-5xl mx-auto border-t border-border pt-10 lg:pt-12">
+      <div className="max-w-6xl mx-auto border-t border-border pt-10 lg:pt-12">
         <motion.h2
           className="type-h2"
           initial={{ opacity: 0, y: 30 }}

--- a/src/components/vignettes/VignetteContainer.tsx
+++ b/src/components/vignettes/VignetteContainer.tsx
@@ -24,7 +24,7 @@ export default function VignetteContainer({
   return (
     <motion.article
       id={id}
-      className={`w-full bg-white rounded-2xl border border-border ring-1 ring-accent-500/20 shadow-md ${
+      className={`w-full h-full bg-white rounded-2xl border border-border/60 shadow-sm ${
         allowOverflow ? 'overflow-visible' : 'overflow-hidden'
       } ${className}`}
       {...fadeInUp}

--- a/src/components/vignettes/VignetteSplit.tsx
+++ b/src/components/vignettes/VignetteSplit.tsx
@@ -14,6 +14,8 @@ interface VignetteSplitProps {
   variant?: 'default' | 'hero';
   /** Disable entrance animations (useful if parent handles it) */
   animateEntrance?: boolean;
+  /** Force stacked layout (useful for compact containers) */
+  compact?: boolean;
 }
 
 export default function VignetteSplit({
@@ -23,6 +25,7 @@ export default function VignetteSplit({
   children,
   variant = 'default',
   animateEntrance = true,
+  compact = false,
 }: VignetteSplitProps) {
   const reducedMotion = useReducedMotion();
   const t = reducedMotion ? timingReduced : timing;
@@ -32,6 +35,11 @@ export default function VignetteSplit({
 
   const titleClass = variant === 'hero' ? 'type-display' : 'type-h2';
   const descriptionClass = 'type-body';
+
+  // Grid classes - compact forces single column, otherwise responsive
+  const gridClass = compact
+    ? 'grid grid-cols-1 gap-8'
+    : 'grid grid-cols-1 xl:grid-cols-[320px_1fr] 2xl:grid-cols-[360px_1fr] gap-8 xl:gap-10 xl:items-center';
 
   // Animation variants for text column (appears first)
   const textVariants = {
@@ -64,7 +72,7 @@ export default function VignetteSplit({
   // When animations are disabled, render static
   if (!animateEntrance) {
     return (
-      <div className="grid grid-cols-1 lg:grid-cols-[360px_1fr] xl:grid-cols-[400px_1fr] gap-10 lg:gap-12 lg:items-center">
+      <div className={gridClass}>
         <div className={textStackClass}>
           {title && <h3 className={titleClass}>{title}</h3>}
           {description && <p className={descriptionClass}>{description}</p>}
@@ -80,7 +88,7 @@ export default function VignetteSplit({
   }
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-[360px_1fr] xl:grid-cols-[400px_1fr] gap-10 lg:gap-12 lg:items-center">
+    <div className={gridClass}>
       {/* Text column - animates first */}
       <motion.div
         className={textStackClass}

--- a/src/components/vignettes/VignetteSplit.tsx
+++ b/src/components/vignettes/VignetteSplit.tsx
@@ -33,7 +33,7 @@ export default function VignetteSplit({
   const hasTitle = Boolean(title);
   const textStackClass = hasTitle ? 'space-y-4' : 'space-y-3';
 
-  const titleClass = variant === 'hero' ? 'type-display' : 'type-h2';
+  const titleClass = variant === 'hero' ? 'type-display' : 'type-h3';
   const descriptionClass = 'type-body';
 
   // Grid classes - compact forces single column, otherwise responsive

--- a/src/components/vignettes/VignetteStaged.tsx
+++ b/src/components/vignettes/VignetteStaged.tsx
@@ -62,7 +62,7 @@ function VignetteStagedInner({
             {/* Iterations header */}
             {currentStageContent?.title && (
               <div className="space-y-3">
-                <h3 className="type-h2">
+                <h3 className="type-h3">
                   {currentStageContent.title}
                 </h3>
                 {currentStageContent.description && (

--- a/src/components/vignettes/ai-highlights/HighlightsPanel.tsx
+++ b/src/components/vignettes/ai-highlights/HighlightsPanel.tsx
@@ -183,13 +183,13 @@ function LoadingState() {
   );
 }
 
-// Positions for scattered feedback cards
+// Positions for scattered feedback cards - evenly distributed with organic feel
 const feedbackCardPositions = [
-  { top: '5%', left: '5%', rotate: -3 },
-  { top: '8%', right: '8%', rotate: 2 },
-  { top: '35%', left: '8%', rotate: -2 },
-  { top: '38%', right: '5%', rotate: 3 },
-  { top: '62%', left: '12%', rotate: -2 },
+  { top: '5%', left: '5%', rotate: -4, z: 1 },
+  { top: '12%', left: '35%', rotate: 3, z: 2 },
+  { top: '6%', left: '65%', rotate: -2, z: 1 },
+  { top: '38%', left: '18%', rotate: 5, z: 3 },
+  { top: '42%', left: '55%', rotate: -3, z: 2 },
 ];
 
 function ProblemState({ cards, onTransition }: { cards: FeedbackSource[]; onTransition?: () => void }) {
@@ -216,7 +216,7 @@ function ProblemState({ cards, onTransition }: { cards: FeedbackSource[]; onTran
             {card.from && (
               <div className="flex items-center gap-2 mb-2">
                 {card.avatarUrl && (
-                  <img src={card.avatarUrl} alt={card.from} className="w-6 h-6 rounded-full" />
+                  <img src={card.avatarUrl} alt={card.from} className="w-6 h-6 rounded-full grayscale" />
                 )}
                 <span className="text-body-sm font-semibold text-primary">{card.from}</span>
               </div>
@@ -233,11 +233,11 @@ function ProblemState({ cards, onTransition }: { cards: FeedbackSource[]; onTran
           return (
             <motion.div
               key={card.id}
-              className="absolute bg-white px-4 py-3 rounded-lg shadow-sm border border-gray-200 max-w-[220px]"
+              className="absolute bg-white px-4 py-3 rounded-lg shadow-sm border border-gray-200 max-w-[220px] backface-hidden will-change-transform"
               style={{
                 top: pos.top,
                 left: pos.left,
-                right: pos.right,
+                zIndex: pos.z,
                 transform: `rotate(${pos.rotate}deg)`,
               }}
               initial={{ opacity: 0, y: 20, scale: 0.9 }}
@@ -251,7 +251,7 @@ function ProblemState({ cards, onTransition }: { cards: FeedbackSource[]; onTran
               {card.from && (
                 <div className="flex items-center gap-2 mb-2">
                   {card.avatarUrl && (
-                    <img src={card.avatarUrl} alt={card.from} className="w-6 h-6 rounded-full" />
+                    <img src={card.avatarUrl} alt={card.from} className="w-6 h-6 rounded-full grayscale" />
                   )}
                   <span className="text-body-sm font-semibold text-primary">{card.from}</span>
                 </div>

--- a/src/components/vignettes/ai-suggestions/AISuggestionsVignette.tsx
+++ b/src/components/vignettes/ai-suggestions/AISuggestionsVignette.tsx
@@ -60,6 +60,7 @@ function AISuggestionsContent() {
 
   return (
     <VignetteSplit
+      compact
       title={
         <div className="space-y-4">
           <StageIndicator stage={stage} onStageChange={setStage} />

--- a/src/components/vignettes/hero/HeroContent.tsx
+++ b/src/components/vignettes/hero/HeroContent.tsx
@@ -35,7 +35,7 @@ export default function HeroContent() {
 
       {/* Single row: Role + Previous + LinkedIn */}
       <motion.p
-        className="flex items-center gap-3 flex-wrap text-secondary"
+        className="flex items-center gap-3 flex-wrap text-stone-600"
         style={{ willChange: 'transform, opacity' }}
         initial={reducedMotion ? false : { opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
@@ -65,11 +65,11 @@ export default function HeroContent() {
           </a>
         </span>
 
-        <span className="text-tertiary">·</span>
+        <span className="text-stone-400">·</span>
 
         {/* Previously */}
         <span className="flex items-center gap-2">
-          <span className="text-tertiary">Previously</span>
+          <span>Previously</span>
           {heroContent.companies.slice(1).map((company) => (
             <a
               key={company.name}
@@ -106,14 +106,14 @@ export default function HeroContent() {
           ))}
         </span>
 
-        <span className="text-tertiary">·</span>
+        <span className="text-stone-400">·</span>
 
         {/* LinkedIn */}
         <a
           href="https://www.linkedin.com/in/idamadam/"
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex text-tertiary hover-linkedin transition-colors duration-200"
+          className="inline-flex text-stone-500 hover-linkedin transition-colors duration-200"
           aria-label="Connect on LinkedIn"
         >
           <svg

--- a/src/components/vignettes/hero/HeroContent.tsx
+++ b/src/components/vignettes/hero/HeroContent.tsx
@@ -48,7 +48,10 @@ export default function HeroContent() {
         {/* Current role */}
         <span className="flex items-center gap-2">
           <span>Lead Product Designer at</span>
-          <span
+          <a
+            href={heroContent.companies[0].url}
+            target="_blank"
+            rel="noopener noreferrer"
             className="inline-flex opacity-70 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-200"
             title={heroContent.companies[0].name}
           >
@@ -59,7 +62,7 @@ export default function HeroContent() {
               height={28}
               className="h-5 w-auto"
             />
-          </span>
+          </a>
         </span>
 
         <span className="text-tertiary">·</span>
@@ -68,9 +71,12 @@ export default function HeroContent() {
         <span className="flex items-center gap-2">
           <span className="text-tertiary">Previously</span>
           {heroContent.companies.slice(1).map((company) => (
-            <span
+            <a
               key={company.name}
-              className="opacity-50 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-200"
+              href={company.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group/logo relative opacity-50 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-200"
               title={company.name}
             >
               <Image
@@ -78,9 +84,25 @@ export default function HeroContent() {
                 alt={company.name}
                 width={80}
                 height={24}
-                className="h-4 w-auto"
+                className={`h-4 w-auto ${company.hoverColor ? 'group-hover/logo:opacity-0' : ''}`}
               />
-            </span>
+              {company.hoverColor && (
+                <span
+                  className="absolute inset-0 opacity-0 group-hover/logo:opacity-100 transition-opacity duration-200"
+                  style={{
+                    backgroundColor: company.hoverColor,
+                    maskImage: `url(${company.logo})`,
+                    maskSize: 'contain',
+                    maskRepeat: 'no-repeat',
+                    maskPosition: 'center',
+                    WebkitMaskImage: `url(${company.logo})`,
+                    WebkitMaskSize: 'contain',
+                    WebkitMaskRepeat: 'no-repeat',
+                    WebkitMaskPosition: 'center',
+                  }}
+                />
+              )}
+            </a>
           ))}
         </span>
 
@@ -91,7 +113,7 @@ export default function HeroContent() {
           href="https://www.linkedin.com/in/idamadam/"
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex text-tertiary hover:text-accent-500 transition-colors duration-200"
+          className="inline-flex text-tertiary hover-linkedin transition-colors duration-200"
           aria-label="Connect on LinkedIn"
         >
           <svg

--- a/src/components/vignettes/hero/HeroVignette.tsx
+++ b/src/components/vignettes/hero/HeroVignette.tsx
@@ -36,7 +36,7 @@ export default function HeroVignette() {
       }}
     >
       <motion.div
-        className="max-w-5xl w-full mx-auto"
+        className="max-w-6xl w-full mx-auto"
         style={{ willChange: 'transform' }}
         initial={false}
         animate={{

--- a/src/components/vignettes/hero/content.ts
+++ b/src/components/vignettes/hero/content.ts
@@ -2,6 +2,8 @@ export interface Company {
   name: string;
   logo: string;
   type: 'svg' | 'png';
+  url: string;
+  hoverColor?: string;
 }
 
 export interface HeroContent {
@@ -12,8 +14,8 @@ export interface HeroContent {
 export const heroContent: HeroContent = {
   name: 'Idam Adam',
   companies: [
-    { name: 'Culture Amp', logo: '/logos/cultureamp.svg', type: 'svg' },
-    { name: 'MYOB', logo: '/logos/myob.svg', type: 'svg' },
-    { name: 'Canstar', logo: '/logos/canstar-gold-and-blue-logo.png', type: 'png' },
+    { name: 'Culture Amp', logo: '/logos/cultureamp.svg', type: 'svg', url: 'https://cultureamp.com' },
+    { name: 'MYOB', logo: '/logos/myob.svg', type: 'svg', url: 'https://myob.com', hoverColor: 'oklch(0.5147 0.2738 294.67)' },
+    { name: 'Canstar', logo: '/logos/canstar-gold-and-blue-logo.png', type: 'png', url: 'https://canstar.com.au' },
   ],
 };

--- a/src/components/vignettes/home-connect/ProblemPanel.tsx
+++ b/src/components/vignettes/home-connect/ProblemPanel.tsx
@@ -102,8 +102,8 @@ export default function ProblemPanel({ onTransition }: ProblemPanelProps) {
               left: item.position.left,
               zIndex: item.zIndex,
             }}
-            initial={{ opacity: 0, scale: 0.9, rotate: 0 }}
-            animate={{ opacity: 1, scale: 1, rotate: item.rotate }}
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
             transition={{
               delay: reducedMotion ? 0 : entranceDelay + i * stagger,
               duration: 0.4,

--- a/src/components/vignettes/home-connect/TransitionPanel.tsx
+++ b/src/components/vignettes/home-connect/TransitionPanel.tsx
@@ -106,7 +106,7 @@ export default function TransitionPanel({ onComplete }: TransitionPanelProps) {
         {scatteredCards.map((card, index) => (
           <motion.div
             key={card.id}
-            className="absolute w-[180px] bg-[#F9F9F9] rounded-lg overflow-hidden shadow-[0px_4px_12px_0px_rgba(0,0,0,0.1)]"
+            className="absolute w-[180px] bg-[#F9F9F9] rounded-lg overflow-hidden shadow-[0px_4px_12px_0px_rgba(0,0,0,0.1)] backface-hidden will-change-transform"
             initial={{
               x: card.scattered.x,
               y: card.scattered.y,

--- a/src/components/vignettes/prototyping/PrototypingVignette.tsx
+++ b/src/components/vignettes/prototyping/PrototypingVignette.tsx
@@ -34,6 +34,7 @@ function PrototypingContent() {
 
   return (
     <VignetteSplit
+      compact
       title={
         <div className="space-y-4">
           <StageIndicator stage={stage} onStageChange={setStage} />

--- a/thoughts/shared/research/2025-12-29-portfolio-layout-patterns.md
+++ b/thoughts/shared/research/2025-12-29-portfolio-layout-patterns.md
@@ -1,0 +1,118 @@
+---
+date: 2025-12-29T23:58:45+11:00
+git_commit: 6358210725b49e7c1e29c9d41d365fd1dfae2dfd
+branch: small-fixes
+repository: idamadam.com
+topic: "Portfolio layout patterns beyond single column"
+tags: [research, ux-patterns, layout, homepage, vignettes]
+status: complete
+last_updated: 2025-12-29
+last_updated_by: claude
+---
+
+# Research: Portfolio Layout Patterns Beyond Single Column
+
+You're looking to move beyond the traditional single card and column layout for your portfolio site, prioritizing **visual impact** and **content hierarchy**, with mobile responsiveness as a key constraint.
+
+## Recommendation
+
+**Use a Bento Grid layout** with varied card sizes to create visual hierarchy. Your "flagship" vignettes (AI Highlights, AI Suggestions) get 2-column spans, while supporting work uses standard 1-column cards. This creates natural emphasis without overhauling your component system, and collapses gracefully to single-column on mobile.
+
+## Quick Comparison
+
+| Option | Mobile | Uses Existing | Effort | Verdict |
+|--------|--------|---------------|--------|---------|
+| Bento Grid | ✓ Single-column collapse | VignetteContainer, Framer Motion | 3-4h | **Recommended** |
+| Featured Hero + Grid | ✓ Stacks naturally | Minor container tweaks | 2-3h | Quick alternative |
+| Asymmetric Split | ⚠️ Needs careful handling | Partial | 6-8h | Skip unless brand fit |
+
+## Constraints Considered
+
+- **Stack**: Next.js 16, Tailwind CSS 4, Framer Motion 12, React 19
+- **Existing patterns**: VignetteContainer (rounded cards with shadow), VignetteSplit (two-column), fadeInUp animations
+- **Priority**: Visual impact + content hierarchy, must work on mobile
+- **Current layout**: max-w-5xl (1024px), space-y-12/14 vertical rhythm
+
+## Option A: Bento Grid (Recommended)
+
+### Why this works
+Bento grids create natural visual hierarchy through card size variation. Your most impactful vignettes span two columns, drawing the eye immediately. The grid structure collapses to single-column on mobile without any layout gymnastics. You keep your existing VignetteContainer styling—just wrap them in a CSS Grid parent.
+
+### Implementation sketch
+```tsx
+// src/app/page.tsx - Vignettes section
+<section className="w-full pb-16 lg:pb-24 px-6 lg:px-12">
+  <div className="max-w-6xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-8">
+    {/* Featured vignette - spans 2 columns */}
+    <div className="lg:col-span-2">
+      <AIHighlightsVignette />
+    </div>
+
+    {/* Standard vignettes - 1 column each */}
+    <AISuggestionsVignette />
+    <PrototypingVignette />
+
+    {/* Another featured span */}
+    <div className="lg:col-span-2">
+      <MultilingualVignette />
+    </div>
+
+    <HomeConnectVignette />
+    <VibeCodingVignette />
+  </div>
+</section>
+```
+
+### Changes needed
+1. **page.tsx**: Replace `space-y-12` container with CSS Grid
+2. **VignetteContainer**: May need `h-full` to equalize heights in grid cells
+3. **VignetteSplit**: Consider if 2-col span vignettes should have different internal proportions
+4. **Max-width**: Bump from `max-w-5xl` to `max-w-6xl` to accommodate grid
+
+### Gotchas
+- Vignettes with VignetteSplit (two internal columns) need testing at narrower widths when they're in a 1-col grid cell
+- Height equalization—if cards have vastly different content lengths, consider `min-h-[500px]` or similar
+- Stagger animations may need adjustment for 2-column reveal timing
+
+## Option B: Featured Hero + Grid
+
+### Why this works
+Lead with your strongest vignette at full-width (hero treatment), then show remaining work in a 2-column grid below. Creates clear hierarchy without complex grid spanning.
+
+### Implementation sketch
+```tsx
+<section>
+  {/* Hero - full width, larger scale */}
+  <div className="max-w-6xl mx-auto px-6 mb-12">
+    <AIHighlightsVignette variant="hero" />
+  </div>
+
+  {/* Grid - remaining work */}
+  <div className="max-w-6xl mx-auto px-6 grid grid-cols-1 lg:grid-cols-2 gap-6">
+    <AISuggestionsVignette />
+    <PrototypingVignette />
+    {/* ... */}
+  </div>
+</section>
+```
+
+### Gotchas
+- Need to create a "hero" variant for VignetteContainer/VignetteSplit with larger typography
+- Less flexibility than bento for reordering content
+
+## What I Ruled Out
+
+- **Masonry layout**: Accessibility concerns with tab order, and native CSS masonry has poor browser support (Firefox/Safari only). Not worth the tradeoffs for a portfolio.
+- **Horizontal scrolling**: Breaks mobile conventions and hides content. Works for timeline-specific use cases but not general portfolio.
+- **Asymmetric/scattered layouts**: High visual impact but requires significant custom CSS per section, doesn't reuse your existing component system well, and mobile adaptation is complex.
+- **Multi-column CSS**: Great for image galleries but your vignettes are interactive components that shouldn't break across columns.
+
+## Sources
+
+- [BentoGrids.com](https://bentogrids.com) - Curated bento design examples
+- [Mockuuups Studio - Best Bento Grid Examples](https://mockuuups.studio/blog/post/best-bento-grid-design-examples/) - Real-world bento implementations
+- [One Page Love - Bento Collection](https://onepagelove.com/tag/bento) - 46 bento grid websites with full screenshots
+- [Speckyboy - Asymmetrical Split Screens](https://speckyboy.com/asymmetrical-split-screens-web-design/) - Creative split layouts
+- [618 Media - Asymmetrical Layouts](https://618media.com/en/blog/asymmetrical-layouts-dynamic-web-design/) - Dynamic asymmetric patterns
+- [Smashing Magazine - Native CSS Masonry](https://www.smashingmagazine.com/native-css-masonry-layout-css-grid/) - Technical masonry deep-dive
+- [Linkero - Website Layout Design Examples](https://linke.ro/blog/website-layout-design-examples) - Grid and hero patterns


### PR DESCRIPTION
## Summary
- Redistribute AI Highlights feedback cards evenly across the panel to avoid unnatural two-column gaps at wider viewports
- Add grayscale filter to problem state avatars to reduce visual distraction
- Remove rotation from Home Connect cards to fix blurry text rendering

## Test plan
- [ ] View AI Highlights vignette at various viewport widths - cards should be evenly scattered
- [ ] Verify problem state avatars are grayscale, solution state avatars are colored
- [ ] Check Home Connect cards for crisp text rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)