### PR TITLE
Improve vignette design notes UX

### DIFF
--- a/src/components/demos/RichTextEditor.tsx
+++ b/src/components/demos/RichTextEditor.tsx
@@ -11,6 +11,8 @@ interface RichTextEditorProps {
   isImproveActivated?: boolean;
   className?: string;
   improveButtonMarker?: ReactNode;
+  improveButtonStyle?: React.CSSProperties;
+  editorContentStyle?: React.CSSProperties;
   mobileFormatting?: 'show' | 'dots';
 }
 
@@ -23,6 +25,8 @@ export default function RichTextEditor({
   isImproveActivated = false,
   className = '',
   improveButtonMarker,
+  improveButtonStyle,
+  editorContentStyle,
   mobileFormatting = 'show'
 }: RichTextEditorProps) {
   return (
@@ -32,7 +36,7 @@ export default function RichTextEditor({
         <div className="bg-background-elevated flex items-center gap-1.5 p-1.5">
           {/* Mobile placeholder dots - shown when mobileFormatting="dots" */}
           {mobileFormatting === 'dots' && (
-            <div className="flex sm:hidden items-center gap-1.5 px-2">
+            <div className="flex sm:hidden items-center gap-1.5 px-2" style={editorContentStyle}>
               {[...Array(4)].map((_, i) => (
                 <div key={i} className="size-2.5 rounded-full bg-gray-300" />
               ))}
@@ -40,7 +44,7 @@ export default function RichTextEditor({
           )}
 
           {/* Formatting buttons */}
-          <div className={`${mobileFormatting === 'dots' ? 'hidden sm:flex' : 'flex'} items-center gap-1.5`}>
+          <div className={`${mobileFormatting === 'dots' ? 'hidden sm:flex' : 'flex'} items-center gap-1.5`} style={editorContentStyle}>
             {/* Text formatting */}
             <button className="bg-background-elevated hover:bg-black/5 p-3.5 rounded-lg size-12 flex items-center justify-center transition-colors">
               <span className="material-icons-outlined text-h3 text-primary">format_bold</span>
@@ -66,7 +70,7 @@ export default function RichTextEditor({
 
           {/* Improve button */}
           {showImproveButton && (
-            <div className="relative">
+            <div className="relative" style={improveButtonStyle}>
               {improveButtonMarker}
               <button
                 onClick={onImprove}
@@ -88,7 +92,7 @@ export default function RichTextEditor({
         <div className="h-0.5 bg-[#878792] w-full" />
 
         {/* Content Area */}
-        <div className="bg-background-elevated p-3.5 min-h-[80px]">
+        <div className="bg-background-elevated p-3.5 min-h-[80px]" style={editorContentStyle}>
           {content ? (
             <p className="text-base leading-6 text-primary whitespace-pre-wrap">
               {content}

--- a/src/components/vignettes/ai-highlights/AIHighlightsVignette.tsx
+++ b/src/components/vignettes/ai-highlights/AIHighlightsVignette.tsx
@@ -21,7 +21,7 @@ type PanelStage = 'problem' | 'loading' | 'solution' | 'designNotes';
 const NOTE_TO_SECTION: Record<string, string> = {
   'context-first': 'summary',
   'verification': 'highlight',
-  'sources': 'opportunity',
+  'sources': 'sources-expand',
 };
 
 function AIHighlightsContent() {

--- a/src/components/vignettes/ai-highlights/AIHighlightsVignette.tsx
+++ b/src/components/vignettes/ai-highlights/AIHighlightsVignette.tsx
@@ -83,14 +83,14 @@ function AIHighlightsContent() {
           onNoteOpenChange={handleNoteOpenChange}
           notes={aiHighlightsContent.designNotes.notes}
         />
-        {/* Mobile: Design notes button (desktop markers are embedded in panel) */}
-        {stage === 'solution' && (
-          <DesignNotesOverlay
-            notes={aiHighlightsContent.designNotes.notes}
-            onActiveNoteChange={handleActiveNoteChange}
-          />
-        )}
       </div>
+      {/* Mobile: Design notes button (desktop markers are embedded in panel) */}
+      {stage === 'solution' && (
+        <DesignNotesOverlay
+          notes={aiHighlightsContent.designNotes.notes}
+          onActiveNoteChange={handleActiveNoteChange}
+        />
+      )}
     </VignetteSplit>
   );
 }

--- a/src/components/vignettes/ai-highlights/HighlightsPanel.tsx
+++ b/src/components/vignettes/ai-highlights/HighlightsPanel.tsx
@@ -322,9 +322,9 @@ function SolutionState({ className = '', highlightedSection = null, onNoteOpenCh
           />
           <div className="flex items-center gap-3 mb-2">
           <img
-            src="/avatars/idam.svg"
+            src="/avatars/headshot.jpg"
             alt="Idam Adam"
-            className="w-12 h-12 rounded-full shadow-sm"
+            className="w-12 h-12 rounded-full shadow-sm object-cover"
           />
           <div>
             <p className="text-h3 font-normal text-primary" style={{ marginBottom: '0px' }}>
@@ -437,7 +437,7 @@ function SolutionState({ className = '', highlightedSection = null, onNoteOpenCh
       </div>
 
       {/* Opportunity Item */}
-      <div className="border-b-2 border-border" data-section-id="opportunity" style={getSectionStyle('opportunity')}>
+      <div className="border-b-2 border-border" data-section-id="opportunity">
         <div className="px-6 py-8">
           {/* Header row with marker */}
           <div className="relative">
@@ -445,12 +445,13 @@ function SolutionState({ className = '', highlightedSection = null, onNoteOpenCh
               index={2}
               noteId="sources"
               side="right"
-              isActive={highlightedSection === 'opportunity'}
+              isActive={highlightedSection === 'sources-expand'}
               onOpenChange={handleNoteOpen}
               note={getNote('sources')}
             />
             <div className="flex flex-col sm:flex-row sm:items-center gap-3">
-              <div className="flex-1">
+              {/* Title and description - dims when sources highlighted */}
+              <div className="flex-1" style={getSectionStyle('opportunity-title')}>
                 <div className="flex items-center gap-1 mb-2">
                   <span className="material-icons-outlined text-h3" style={{ color: 'rgba(135, 100, 0, 1)' }}>
                   lightbulb
@@ -464,7 +465,12 @@ function SolutionState({ className = '', highlightedSection = null, onNoteOpenCh
               </p>
             </div>
 
-            <div className="flex items-center gap-2 shrink-0">
+            {/* Sources row - highlighted when sources note is active */}
+            <div
+              className="flex items-center gap-2 shrink-0"
+              data-section-id="sources-expand"
+              style={getSectionStyle('sources-expand')}
+            >
               <div className="flex items-center gap-1">
                 <div className="flex -space-x-2">
                   <img
@@ -507,6 +513,7 @@ function SolutionState({ className = '', highlightedSection = null, onNoteOpenCh
                 exit={{ height: 0, opacity: 0 }}
                 transition={{ duration: 0.3, ease: 'easeInOut' }}
                 className="overflow-hidden"
+                style={getSectionStyle('sources-expand')}
               >
                 <div className="mt-4 space-y-4">
                   <SourceCard
@@ -531,7 +538,7 @@ function SolutionState({ className = '', highlightedSection = null, onNoteOpenCh
       </div>
 
       {/* Footer with Feedback Buttons */}
-      <div className="px-6 py-4 flex items-center gap-2">
+      <div className="px-6 py-4 flex items-center gap-2" style={getSectionStyle('footer')}>
         <span className="text-body-sm text-secondary">
           Is this helpful?
         </span>

--- a/src/components/vignettes/ai-suggestions/AISuggestionsVignette.tsx
+++ b/src/components/vignettes/ai-suggestions/AISuggestionsVignette.tsx
@@ -20,7 +20,7 @@ type PanelStage = 'problem' | 'loading' | 'solution' | 'designNotes';
 // Map note IDs to the content sections they reference
 const NOTE_TO_SECTION: Record<string, string> = {
   'editor-integration': 'improve-button',
-  'people-science': 'recommendations-header',
+  'people-science': 'recommendations-list',
   'loading-state': 'gradient-border',
 };
 

--- a/src/components/vignettes/ai-suggestions/AISuggestionsVignette.tsx
+++ b/src/components/vignettes/ai-suggestions/AISuggestionsVignette.tsx
@@ -81,14 +81,14 @@ function AISuggestionsContent() {
           onNoteOpenChange={handleNoteOpenChange}
           notes={aiSuggestionsContent.designNotes.notes}
         />
-        {/* Mobile: Design notes button (desktop markers are embedded in panel) */}
-        {stage === 'solution' && (
-          <DesignNotesOverlay
-            notes={aiSuggestionsContent.designNotes.notes}
-            onActiveNoteChange={handleActiveNoteChange}
-          />
-        )}
       </div>
+      {/* Mobile: Design notes button (desktop markers are embedded in panel) */}
+      {stage === 'solution' && (
+        <DesignNotesOverlay
+          notes={aiSuggestionsContent.designNotes.notes}
+          onActiveNoteChange={handleActiveNoteChange}
+        />
+      )}
     </VignetteSplit>
   );
 }

--- a/src/components/vignettes/ai-suggestions/SuggestionsPanel.tsx
+++ b/src/components/vignettes/ai-suggestions/SuggestionsPanel.tsx
@@ -206,7 +206,7 @@ function RecommendationsPanel({
           index={2}
           noteId="people-science"
           side="right"
-          isActive={highlightedSection === 'recommendations-header'}
+          isActive={highlightedSection === 'recommendations-list'}
           onOpenChange={handleNoteOpen}
           note={getNote('people-science')}
         />
@@ -233,7 +233,11 @@ function RecommendationsPanel({
           </div>
 
           {/* Recommendations */}
-          <div className="space-y-4">
+          <div
+            className="space-y-4"
+            data-section-id="recommendations-list"
+            style={getSectionStyle('recommendations-list')}
+          >
             {content.recommendations.map((rec, index) => (
               <div key={index}>
                 <p className="text-base leading-6 text-primary">
@@ -248,7 +252,11 @@ function RecommendationsPanel({
           </div>
 
           {/* Footer */}
-          <div className="flex items-center pt-2">
+          <div
+            className="flex items-center pt-2"
+            data-section-id="recommendations-footer"
+            style={getSectionStyle('recommendations-footer')}
+          >
             <div className="flex items-center gap-4">
               <span className="text-sm text-secondary">Is this helpful?</span>
               <button className="p-2 hover:bg-black/5 rounded-lg transition-colors">
@@ -301,11 +309,7 @@ export default function SuggestionsPanel({
     <div className="space-y-2">
       <GradientBorderStyles />
       {/* Editor with marker - always visible */}
-      <div
-        className="relative"
-        data-section-id="improve-button"
-        style={isSolution ? getSectionStyle('improve-button') : undefined}
-      >
+      <div className="relative" data-section-id="improve-button">
         <RichTextEditor
           content={content.beforeText}
           placeholder="Write feedback..."
@@ -314,6 +318,8 @@ export default function SuggestionsPanel({
           isImproveActivated={isSolution}
           onImprove={isProblem ? onTransition : undefined}
           mobileFormatting="dots"
+          improveButtonStyle={isSolution ? getSectionStyle('improve-button') : undefined}
+          editorContentStyle={isSolution ? getSectionStyle('editor-content') : undefined}
           improveButtonMarker={
             isSolution ? (
               <SectionMarker

--- a/src/components/vignettes/home-connect/HomeConnectContent.tsx
+++ b/src/components/vignettes/home-connect/HomeConnectContent.tsx
@@ -100,14 +100,14 @@ export default function HomeConnectContent({
           )}
         </AnimatePresence>
 
-        {/* Mobile: Design notes button (desktop markers are embedded in panel) */}
-        {stage === 'solution' && (
-          <DesignNotesOverlay
-            notes={notes}
-            onActiveNoteChange={onActiveNoteChange}
-          />
-        )}
       </div>
+      {/* Mobile: Design notes button (desktop markers are embedded in panel) */}
+      {stage === 'solution' && (
+        <DesignNotesOverlay
+          notes={notes}
+          onActiveNoteChange={onActiveNoteChange}
+        />
+      )}
     </VignetteSplit>
   );
 }

--- a/src/components/vignettes/multilingual/MultilingualVignette.tsx
+++ b/src/components/vignettes/multilingual/MultilingualVignette.tsx
@@ -125,14 +125,14 @@ function MultilingualContent() {
           )}
         </AnimatePresence>
 
-        {/* Mobile: Design notes button (desktop markers are embedded in panel) */}
-        {panelStage === 'solution' && (
-          <DesignNotesOverlay
-            notes={multilingualContent.designNotes.notes}
-            onActiveNoteChange={handleActiveNoteChange}
-          />
-        )}
       </div>
+      {/* Mobile: Design notes button (desktop markers are embedded in panel) */}
+      {panelStage === 'solution' && (
+        <DesignNotesOverlay
+          notes={multilingualContent.designNotes.notes}
+          onActiveNoteChange={handleActiveNoteChange}
+        />
+      )}
     </VignetteSplit>
   );
 }

--- a/src/components/vignettes/multilingual/TranslationManagementPanel.tsx
+++ b/src/components/vignettes/multilingual/TranslationManagementPanel.tsx
@@ -73,7 +73,7 @@ export default function TranslationManagementPanel({
   return (
     <div className={`w-full space-y-6 ${className}`}>
       {/* Language & Action Buttons */}
-      <div className="flex flex-col sm:flex-row items-start sm:items-end gap-3">
+      <div className="flex flex-col sm:flex-row items-start sm:items-end gap-3 sm:gap-12">
         {/* Language Dropdown */}
         <div
           className="flex flex-col gap-1.5 w-full sm:w-auto relative"

--- a/src/components/vignettes/shared/DesignNotesOverlay.tsx
+++ b/src/components/vignettes/shared/DesignNotesOverlay.tsx
@@ -32,9 +32,9 @@ export function DesignNotesOverlay({ notes, onActiveNoteChange }: DesignNotesOve
 
   return (
     <>
-      {/* Mobile: Single button to open notes sheet */}
+      {/* Mobile: Button below panel to open notes sheet */}
       <motion.button
-        className="lg:hidden absolute bottom-4 right-4 z-20 flex items-center gap-2 px-4 py-2.5
+        className="lg:hidden mt-4 ml-auto z-20 flex items-center gap-2 px-4 py-2.5
                    bg-[var(--accent-500)] text-white text-sm font-medium rounded-full shadow-lg
                    hover:bg-[var(--accent-600)] transition-colors"
         onClick={() => openMobileSheet(0)}


### PR DESCRIPTION
## Summary
- Fix section marker overlap on multilingual action buttons
- Improve AI Suggestions design note highlighting precision
- Improve AI Highlights design note highlighting and use real avatar
- Move mobile Design Notes button below panel to avoid conflicts with interactive elements

## Test plan
- [ ] Verify design note markers don't overlap with action buttons on multilingual vignette
- [ ] Check AI Suggestions highlighting dims correct sections when notes are active
- [ ] Confirm AI Highlights uses real avatar and highlighting works correctly
- [ ] Test mobile: Design Notes button appears below panel, not overlapping thumbs/expand buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)