### PR TITLE
Improve sandbox vignette copy and UI

### DIFF
--- a/src/components/vignettes/ai-highlights/content.ts
+++ b/src/components/vignettes/ai-highlights/content.ts
@@ -24,18 +24,14 @@ interface AIHighlightsContent {
 export const aiHighlightsContent: AIHighlightsContent = {
   stages: {
     problem: {
-      title: 'Collating and synthesizing feedback was one of the most time-intensive tasks of writing a performance review',
-      description: '',
+      title: 'Synthesizing feedback was the most time-intensive part of performance reviews',
       cta: 'See how AI helped'
     },
     solution: {
-      title: 'Designed AI summaries managers could verify and trust',
-      description:
-        "I designed an AI system that surfaces key highlights and opportunities from feedback. Managers can expand to see direct quotes, verifying AI outputs while saving significant time during review season."
+      title: 'Designed AI summaries managers could verify and trust'
     },
     designNotes: {
-      title: 'Design notes',
-      description: 'Sharpie-style redlines that show the messy thinking behind the polished surface.'
+      title: 'Design notes'
     }
   },
   iterations: [
@@ -93,7 +89,7 @@ export const aiHighlightsContent: AIHighlightsContent = {
     {
       id: 'feedback1',
       channel: 'feedback',
-      content: "Idam's user research uncovered the core trust issue with AI summaries. This insight shaped our entire product direction.",
+      content: "Idam's user research helped us understand why managers weren't trusting the AI summaries. That insight shaped how we approached the whole feature.",
       from: 'Sarah Chen',
       avatarUrl: '/avatars/sarah-chen.svg'
     },
@@ -101,7 +97,7 @@ export const aiHighlightsContent: AIHighlightsContent = {
       id: 'feedback2',
       channel: 'feedback',
       content:
-        'Outstanding collaboration across design and engineering. The verification UX is both elegant and technically feasible.',
+        'Good collaboration between design and engineering on the verification UX. The solution worked within our technical constraints.',
       from: 'Mike Torres',
       avatarUrl: '/avatars/mike-torres.svg'
     },
@@ -109,7 +105,7 @@ export const aiHighlightsContent: AIHighlightsContent = {
       id: 'feedback3',
       channel: 'feedback',
       content:
-        "Idam ran the most rigorous AI testing process I've seen. Real feedback, real managers, real insights about trust.",
+        "Idam ran thorough testing with real managers and real feedback. The insights about trust were valuable for the team.",
       from: 'Alex Kim',
       avatarUrl: '/avatars/alex-kim.svg'
     },
@@ -117,7 +113,7 @@ export const aiHighlightsContent: AIHighlightsContent = {
       id: 'feedback4',
       channel: 'feedback',
       content:
-        'The inline source expansion is brilliant. Managers can verify AI output without leaving their flow. This will save hours.',
+        'The inline source expansion lets managers verify AI output without breaking their flow. Useful addition to the feature.',
       from: 'Jordan Lee',
       avatarUrl: '/avatars/jordan-lee.svg'
     },
@@ -125,14 +121,14 @@ export const aiHighlightsContent: AIHighlightsContent = {
       id: 'feedback5',
       channel: 'feedback',
       content:
-        'Idam advocated strongly for verification features when we wanted to ship faster. That user-first mindset prevented a trust disaster.',
+        'Idam pushed for verification features when we were considering cutting scope. Turned out to be the right call for user trust.',
       from: 'Sarah Chen',
       avatarUrl: '/avatars/sarah-chen.svg'
     },
     {
       id: 'feedback6',
       channel: 'feedback',
-      content: "Built custom prototyping infrastructure to iterate faster. This unlocked velocity we didn't know was possible.",
+      content: "Built prototyping tools that helped the team iterate faster. Other designers have started using them too.",
       from: 'Mike Torres',
       avatarUrl: '/avatars/mike-torres.svg'
     },
@@ -140,7 +136,7 @@ export const aiHighlightsContent: AIHighlightsContent = {
       id: 'feedback7',
       channel: 'feedback',
       content:
-        "Every design iteration was grounded in user testing data. No ego, just evidence. That's how you ship AI features people trust.",
+        "Design decisions were backed by user testing data. Idam was open to changing direction when the research pointed elsewhere.",
       from: 'Alex Kim',
       avatarUrl: '/avatars/alex-kim.svg'
     },
@@ -148,7 +144,7 @@ export const aiHighlightsContent: AIHighlightsContent = {
       id: 'feedback8',
       channel: 'feedback',
       content:
-        "Idam's attention to the verification interaction details made the difference. AI summaries are worthless if managers don't trust them.",
+        "Idam paid close attention to the details of the verification interaction. Small things like showing avatars helped managers trust the sources.",
       from: 'Jordan Lee',
       avatarUrl: '/avatars/jordan-lee.svg'
     }

--- a/src/components/vignettes/ai-suggestions/content.ts
+++ b/src/components/vignettes/ai-suggestions/content.ts
@@ -21,17 +21,13 @@ export interface AISuggestionsContent {
 export const aiSuggestionsContent: AISuggestionsContent = {
   stages: {
     problem: {
-      title: 'Managers struggled to write constructive, actionable feedback',
-      description: ''
+      title: 'Managers struggled to write constructive, actionable feedback'
     },
     solution: {
-      title: 'Designed AI coaching grounded in people science',
-      description:
-        'I partnered with organizational psychologists to create AI suggestions backed by research. The system scans for specific, impactful, objective, and actionable qualities, giving managers structured guidance to improve their feedback.'
+      title: 'Designed AI coaching grounded in people science'
     },
     designNotes: {
-      title: 'Design notes',
-      description: 'Annotated notes showing the thinking behind the design.'
+      title: 'Design notes'
     }
   },
   designNotes: {
@@ -47,7 +43,7 @@ export const aiSuggestionsContent: AISuggestionsContent = {
       {
         id: 'loading-state',
         label: 'AI visual language',
-        detail: 'Designed the gradient border and associated loading animation as a core signifier of AI features at Culture Amp.',
+        detail: 'The gradient border and loading animation became a core signifier of AI features at Culture Amp.',
         x: '-4%',
         y: '65%',
         popoverSide: 'left' as const,

--- a/src/components/vignettes/home-connect/content.ts
+++ b/src/components/vignettes/home-connect/content.ts
@@ -31,8 +31,6 @@ interface FeedSection {
 }
 
 export interface HomeConnectContent {
-  title: string;
-  description: string;
   stages: VignetteStages;
   designNotes: {
     notes: DesignNote[];
@@ -42,20 +40,13 @@ export interface HomeConnectContent {
 }
 
 export const homeConnectContent: HomeConnectContent = {
-  title: 'Created a cohesive homepage system to bring all of Culture Amp into one place',
-  description:
-    "A centralized navigation hub that reduced platform fragmentation and improved feature discoverability across Culture Amp's product suite.",
-
   stages: {
     problem: {
       title: 'Valuable context was scattered across Culture Amp\'s products',
-      description: 'Performance reviews, 1-on-1s, Goals, and Surveys each lived in their own silo. To piece together what was happening with your team, you had to hunt across four different tools.',
       cta: 'Show the solution'
     },
     solution: {
-      title: 'A unified feed that surfaces what matters',
-      description:
-        'Performance, goals, surveys, and 1-on-1s brought together in one place. Context about your team, without the hunt.'
+      title: 'A unified feed that surfaces what matters'
     }
   },
 
@@ -65,7 +56,7 @@ export const homeConnectContent: HomeConnectContent = {
         id: 'card-system',
         label: 'Card system',
         detail:
-          'I researched and designed a unified card system to surface updates based around the people you care about at work.',
+          'A unified card system surfaces updates based around the people you care about at work.',
         x: '104%',
         y: '35%',
         popoverSide: 'right' as const,
@@ -74,7 +65,7 @@ export const homeConnectContent: HomeConnectContent = {
         id: 'inactive-goal',
         label: 'Inactive goal nudge',
         detail:
-          'A new notification type I designed to drive adoption. Managers can now see when their reports have stalled goals.',
+          'A new notification type to drive adoption. Managers see when their reports have stalled goals.',
         x: '-4%',
         y: '80%',
         popoverSide: 'left' as const,

--- a/src/components/vignettes/multilingual/content.ts
+++ b/src/components/vignettes/multilingual/content.ts
@@ -36,16 +36,6 @@ interface ProblemCard {
 
 
 export interface MultilingualContent {
-  title: string;
-  description: string;
-  section1: {
-    title: string;
-    description: string;
-  };
-  section2: {
-    title: string;
-    description: string;
-  };
   workflows: TranslationWorkflow[];
   translationFields: TranslationField[];
   languages: LanguageOption[];
@@ -60,18 +50,6 @@ export interface MultilingualContent {
 }
 
 export const multilingualContent: MultilingualContent = {
-  title: 'Expanded Performance Reviews to 120+ languages',
-  description:
-    "Global customers ran separate performance cycles for each language, creating massive admin burden. When a $1M+ ARR customer needed multilingual support or they'd churn, I researched workflows and advocated for XLSX uploads and machine translation - expanding scope beyond the original ask. The system enables a single cycle with multiple languages, eliminating operational overhead. $1M+ ARR retained, 4,000+ employees supported.",
-  section1: {
-    title: 'Expanded Performance Reviews to 120+ languages',
-    description:
-      'I designed a flexible translation workflow that supports three input methods: manual editing for quick tweaks, CSV uploads for translation agencies, and machine translation for speed. This was also a milestone for me. I incorporated my native language, Dhivehi, into my work for the first time.'
-  },
-  section2: {
-    title: 'Auto-translate in action',
-    description: 'Machine translation enables managers to launch multilingual performance cycles in minutes.'
-  },
   workflows: [
     {
       id: 1,
@@ -119,12 +97,10 @@ export const multilingualContent: MultilingualContent = {
   stages: {
     problem: {
       title: 'Supporting multiple languages required a separate workflow for each language',
-      description: '',
       cta: 'Show the solution'
     },
     solution: {
-      title: 'Designed a simple way to bring multiple languages into a single cycle',
-      description: 'I designed a flexible translation workflow that supports three input methods: manual editing for quick tweaks, XLSX uploads for admins who wanted more control, and machine translation for speed. This was also a milestone for me. I incorporated my native language, Dhivehi, into my work for the first time.'
+      title: 'Designed a simple way to bring multiple languages into a single cycle'
     }
   },
   designNotes: {

--- a/src/components/vignettes/prototyping/SandboxPanel.tsx
+++ b/src/components/vignettes/prototyping/SandboxPanel.tsx
@@ -46,13 +46,15 @@ function ProblemState({
       </div>
 
       {/* Desktop: Scattered floating questions */}
-      <div className="relative w-full h-36 hidden lg:block">
+      <div className="relative w-full h-44 hidden lg:block">
         {questions.map((q, index) => {
           const positions = [
-            { top: '10%', left: '5%', rotate: -3 },
-            { top: '5%', right: '10%', rotate: 2 },
-            { top: '45%', left: '15%', rotate: -2 },
-            { top: '55%', right: '5%', rotate: 3 },
+            { top: '0%', left: '5%', rotate: -2 },
+            { top: '5%', right: '8%', rotate: 2 },
+            { top: '35%', left: '25%', rotate: -1 },
+            { top: '40%', right: '20%', rotate: 1 },
+            { top: '70%', left: '8%', rotate: 2 },
+            { top: '65%', right: '5%', rotate: -2 },
           ];
           const pos = positions[index % positions.length];
 
@@ -84,7 +86,7 @@ function ProblemState({
         enterDelay={ctaDelay}
         className="mt-4 lg:mt-6"
       >
-        Make it easier
+        See how it works
       </Button>
     </div>
   );
@@ -171,26 +173,28 @@ function SolutionState({ content }: { content: PrototypingContent }) {
           <div className="w-[50px] h-[50px] bg-[#d9d9d9] rounded-full" />
         </div>
 
-        {/* Prototype Grid */}
+        {/* Designer Directory */}
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 sm:gap-lg">
-          {content.prototypes.map((item) => (
+          {content.designers.map((designer) => (
             <div
-              key={item.id}
-              className="rounded-[7px] h-[60px] sm:h-[78px]"
-              style={{ backgroundColor: item.thumbnail }}
-              aria-label={item.name}
-            />
+              key={designer.id}
+              className="flex items-center gap-2 bg-background-subtle rounded-lg p-2 sm:p-3"
+            >
+              <div className="w-8 h-8 sm:w-10 sm:h-10 bg-[#d9d9d9] rounded-full flex-shrink-0" />
+              <span className="text-caption sm:text-body-sm text-primary font-medium truncate">
+                {designer.name}
+              </span>
+            </div>
           ))}
         </div>
       </div>
 
       {/* Claude Code TUI Overlay */}
       <motion.div
-        initial={{ opacity: 0, y: 10, scale: 0.95 }}
-        animate={{ opacity: 1, y: 0, scale: 1 }}
+        initial={{ opacity: 0, y: '95%', scale: 0.95 }}
+        animate={{ opacity: 1, y: '85%', scale: 1 }}
         transition={{ duration: 0.3, ease: 'easeOut', delay: 0.2 }}
-        className="absolute bottom-0 right-0 left-0 sm:left-auto bg-[#09090B] rounded-lg w-full sm:w-[340px] lg:w-[420px] shadow-2xl border border-[#1f1f23] overflow-hidden"
-        style={{ transform: 'translate(0, 50%)' }}
+        className="absolute bottom-0 right-0 left-0 sm:left-auto sm:right-4 bg-[#09090B] rounded-lg w-full sm:w-[340px] lg:w-[420px] shadow-2xl border border-[#1f1f23] overflow-hidden"
       >
         {/* TUI Header */}
         <div className="bg-[#111113] px-4 py-2 rounded-t-lg border-b border-[#1f1f23] flex items-center justify-between">
@@ -207,26 +211,24 @@ function SolutionState({ content }: { content: PrototypingContent }) {
 
         {/* TUI Content */}
         <div className="p-4 pb-10 font-mono text-caption leading-relaxed">
-          {/* Command prompt */}
-          <div className="flex items-start gap-2 mb-3">
+          {/* Command: /add-prototype with remix */}
+          <div className="flex items-start gap-2 mb-2">
             <span className="text-[#D4A27F] select-none">&gt;</span>
-            <span className="text-gray-100">/remix Idam&apos;s prototype and make it my own</span>
+            <span className="text-gray-100">/add-prototype --from @idam/feedback-helper</span>
           </div>
-
-          {/* Command output */}
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
-            transition={{ delay: 0.4 }}
-            className="space-y-2 text-gray-400"
+            transition={{ delay: 0.3 }}
+            className="space-y-1 text-gray-400 pl-4"
           >
             <div className="flex items-center gap-2">
               <span className="text-green-400">✓</span>
-              <span>Found prototype in repository</span>
+              <span>Forked from Idam&apos;s prototype</span>
             </div>
             <div className="flex items-center gap-2">
               <span className="text-green-400">✓</span>
-              <span>Creating your workspace...</span>
+              <span>Copied components &amp; styles</span>
             </div>
             <div className="flex items-center gap-2">
               <motion.span
@@ -236,7 +238,7 @@ function SolutionState({ content }: { content: PrototypingContent }) {
               >
                 ⟳
               </motion.span>
-              <span className="text-gray-300">Customizing components...</span>
+              <span className="text-gray-300">Opening your remix...</span>
             </div>
           </motion.div>
         </div>

--- a/src/components/vignettes/prototyping/content.ts
+++ b/src/components/vignettes/prototyping/content.ts
@@ -37,12 +37,10 @@ export const prototypingContent: PrototypingContent = {
   stages: {
     problem: {
       title: 'Designers & PMs did not know where to start with coding agents',
-      description: '',
-      cta: 'See how I enabled this'
+      cta: 'See the solution'
     },
     solution: {
-      title: 'Created shared infrastructure to unlock AI prototyping at Culture Amp',
-      description: 'I built a common repository that made it easy for designers and PMs to create, share, and remix React prototypes using coding agents. The sandbox removed technical barriers and established a new prototyping discipline.'
+      title: 'Shared infrastructure unlocked AI prototyping across the team'
     }
   },
   sandboxTitle: 'Culture Amp Design Sandbox',

--- a/src/components/vignettes/prototyping/content.ts
+++ b/src/components/vignettes/prototyping/content.ts
@@ -6,6 +6,11 @@ export interface PrototypeItem {
   thumbnail: string;
 }
 
+export interface DesignerItem {
+  id: number;
+  name: string;
+}
+
 export interface ProblemQuestion {
   id: string;
   text: string;
@@ -25,6 +30,7 @@ export interface PrototypingContent {
   stages: VignetteStages;
   sandboxTitle: string;
   prototypes: PrototypeItem[];
+  designers: DesignerItem[];
   problemQuestions: ProblemQuestion[];
   transitionSteps: TransitionStep[];
   adoptionStats: {
@@ -36,11 +42,11 @@ export interface PrototypingContent {
 export const prototypingContent: PrototypingContent = {
   stages: {
     problem: {
-      title: 'Designers & PMs did not know where to start with coding agents',
-      cta: 'See the solution'
+      title: 'Designers had no shared foundation for AI prototyping',
+      cta: 'See how it works'
     },
     solution: {
-      title: 'Shared infrastructure unlocked AI prototyping across the team'
+      title: 'A shared sandbox that makes AI prototyping easy'
     }
   },
   sandboxTitle: 'Culture Amp Design Sandbox',
@@ -52,18 +58,28 @@ export const prototypingContent: PrototypingContent = {
     { id: 5, name: 'Review Writer', thumbnail: '#d9d9d9' },
     { id: 6, name: '1-on-1 Prep', thumbnail: '#d9d9d9' }
   ],
+  designers: [
+    { id: 1, name: 'Sarah Chen' },
+    { id: 2, name: 'Marcus Johnson' },
+    { id: 3, name: 'Priya Patel' },
+    { id: 4, name: 'Alex Kim' },
+    { id: 5, name: 'Jordan Rivera' },
+    { id: 6, name: 'Taylor Brooks' }
+  ],
   problemQuestions: [
-    { id: 'q1', text: 'Where do I start?', delay: 0 },
-    { id: 'q2', text: 'What tools do I use?', delay: 0.15 },
-    { id: 'q3', text: 'How do I set up an environment?', delay: 0.3 },
-    { id: 'q4', text: 'How do I share this?', delay: 0.45 }
+    { id: 'q1', text: 'Everyone starting from scratch', delay: 0 },
+    { id: 'q2', text: 'No shared components', delay: 0.1 },
+    { id: 'q3', text: "Can't build on others' work", delay: 0.2 },
+    { id: 'q4', text: 'Complex setup every time', delay: 0.3 },
+    { id: 'q5', text: 'Hours lost on configuration', delay: 0.4 },
+    { id: 'q6', text: 'Knowledge siloed in individuals', delay: 0.5 }
   ],
   transitionSteps: [
     { id: 'clone-cmd', type: 'command', command: 'git clone culture-amp/design-sandbox', delay: 0 },
     { id: 'clone-status', type: 'status', status: 'Cloned — Components ready', delay: 0.8 },
-    { id: 'prototype-cmd', type: 'command', command: '/new-prototype "My feature idea"', delay: 1.8 },
-    { id: 'prototype-status', type: 'status', status: 'Created workspace', delay: 2.6 },
-    { id: 'opening-status', type: 'status', status: 'Opening your prototype...', isLoading: true, delay: 3.4 },
+    { id: 'designer-cmd', type: 'command', command: '/add-designer "Sarah Chen"', delay: 1.8 },
+    { id: 'designer-status', type: 'status', status: 'Created designer profile', delay: 2.6 },
+    { id: 'homepage-status', type: 'status', status: 'Generating personal homepage...', isLoading: true, delay: 3.4 },
   ],
   adoptionStats: {
     designers: 12,


### PR DESCRIPTION
## Summary
- Reframe vignette from problem/solution to capability unlock narrative
- Update problem state with 6 friction-focused cards instead of confused questions
- Replace prototype grid with designer directory in solution state
- Update loading state to show `/add-designer` onboarding flow
- Update solution TUI to showcase `/add-prototype --from` remix workflow
- Adjust TUI overlay positioning for better visual balance

## Test plan
- [ ] Verify problem state displays 6 floating cards correctly on desktop
- [ ] Verify loading transition shows clone → add-designer flow
- [ ] Verify solution state shows designer directory grid
- [ ] Verify TUI overlay shows remix workflow and is properly positioned
- [ ] Check responsive behavior on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)