### PR TITLE
Visual refinements: single column layout with horizontal vignettes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -82,14 +82,12 @@
 
 /* Glassmorphism card treatment */
 .card-elevated {
-  background: rgba(255, 255, 255, 0.5);
-  backdrop-filter: blur(16px) saturate(180%);
-  -webkit-backdrop-filter: blur(16px) saturate(180%);
-  border: 1px solid rgba(255, 255, 255, 0.6);
-  border-radius: 0.5rem;
-  box-shadow:
-    0 4px 24px rgba(0, 0, 0, 0.08),
-    inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.35);
+  backdrop-filter: blur(12px) saturate(150%);
+  -webkit-backdrop-filter: blur(12px) saturate(150%);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 0.75rem;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.04);
 }
 
 @theme inline {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -10,7 +10,7 @@ export default function Footer() {
 
   return (
     <footer className="w-full py-16 lg:py-20 px-6 lg:px-12 2xl:px-24">
-      <div className="max-w-[1600px] mx-auto border-t border-border pt-10 lg:pt-12">
+      <div className="max-w-[1280px] mx-auto border-t border-border pt-10 lg:pt-12">
         <motion.div
           className="flex flex-col items-center text-center gap-4"
           initial={{ opacity: 0, y: 30 }}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -43,7 +43,7 @@ export default function Header() {
             ease: [0.33, 1, 0.68, 1],
           }}
         >
-          <div className="max-w-[1600px] mx-auto h-16 flex items-center justify-between">
+          <div className="max-w-[1280px] mx-auto h-16 flex items-center justify-between">
             {/* Name */}
             <span className="type-h3 !font-bold">{heroContent.name}</span>
 

--- a/src/components/SectionTitle.tsx
+++ b/src/components/SectionTitle.tsx
@@ -28,7 +28,7 @@ export default function SectionTitle({ children, disableScrollTrigger = false }:
 
   return (
     <section className="w-full pb-10 lg:pb-12 px-6 lg:px-12 2xl:px-24">
-      <div className="max-w-[1600px] mx-auto border-t border-border pt-10 lg:pt-12">
+      <div className="max-w-[1280px] mx-auto border-t border-border pt-10 lg:pt-12">
         <motion.h2
           className="type-h2"
           {...motionProps}

--- a/src/components/SelectedWorkSection.tsx
+++ b/src/components/SelectedWorkSection.tsx
@@ -32,7 +32,7 @@ export default function SelectedWorkSection() {
     >
       <SectionTitle disableScrollTrigger>Work</SectionTitle>
       <section className="w-full pb-16 lg:pb-24 px-6 lg:px-12 2xl:px-24">
-        <div className="max-w-[1600px] mx-auto grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-y-8 lg:gap-x-12 items-start">
+        <div className="max-w-[1280px] mx-auto grid grid-cols-1 gap-12 lg:gap-16 xl:gap-20 items-start">
           <AIHighlightsVignette />
           <AISuggestionsVignette />
           <PrototypingVignette />

--- a/src/components/vignettes/VignetteContainer.tsx
+++ b/src/components/vignettes/VignetteContainer.tsx
@@ -29,7 +29,7 @@ export default function VignetteContainer({
       } ${className}`}
       {...fadeInUp}
     >
-      <div className="p-7 lg:p-10 space-y-10">
+      <div className="p-6 lg:p-10 space-y-8">
         {/* Title Section - Only show if title is provided */}
         {title && (
           <div className="space-y-3">

--- a/src/components/vignettes/VignetteSplit.tsx
+++ b/src/components/vignettes/VignetteSplit.tsx
@@ -36,7 +36,7 @@ export default function VignetteSplit({
   // Grid classes - compact forces single column, otherwise responsive
   const gridClass = compact
     ? 'grid grid-cols-1 gap-8'
-    : 'grid grid-cols-1 xl:grid-cols-[320px_1fr] 2xl:grid-cols-[360px_1fr] gap-8 xl:gap-10 xl:items-center';
+    : 'grid grid-cols-1 xl:grid-cols-[320px_1fr] 2xl:grid-cols-[360px_1fr] gap-8 xl:gap-12 xl:items-center';
 
   // Animation variants for text column (appears first)
   const textVariants = {

--- a/src/components/vignettes/ai-highlights/AIHighlightsVignette.tsx
+++ b/src/components/vignettes/ai-highlights/AIHighlightsVignette.tsx
@@ -61,7 +61,6 @@ function AIHighlightsContent() {
 
   return (
     <VignetteSplit
-      compact
       title={
         <div className="space-y-4">
           <StageIndicator stage={stage} onStageChange={setStage} />

--- a/src/components/vignettes/ai-suggestions/AISuggestionsVignette.tsx
+++ b/src/components/vignettes/ai-suggestions/AISuggestionsVignette.tsx
@@ -59,7 +59,6 @@ function AISuggestionsContent() {
 
   return (
     <VignetteSplit
-      compact
       title={
         <div className="space-y-4">
           <StageIndicator stage={stage} onStageChange={setStage} />

--- a/src/components/vignettes/hero/HeroVignette.tsx
+++ b/src/components/vignettes/hero/HeroVignette.tsx
@@ -52,7 +52,7 @@ export default function HeroVignette() {
       }}
     >
       <motion.div
-        className="max-w-[1600px] w-full mx-auto"
+        className="max-w-[1280px] w-full mx-auto"
         style={{ willChange: 'transform' }}
         initial={false}
         animate={{

--- a/src/components/vignettes/home-connect/HomeConnectContent.tsx
+++ b/src/components/vignettes/home-connect/HomeConnectContent.tsx
@@ -58,7 +58,6 @@ export default function HomeConnectContent({
 
   return (
     <VignetteSplit
-      compact
       title={
         <div className="space-y-4">
           <StageIndicator stage={stage} onStageChange={setStage} />

--- a/src/components/vignettes/home-connect/ProblemPanel.tsx
+++ b/src/components/vignettes/home-connect/ProblemPanel.tsx
@@ -2,23 +2,29 @@
 
 import { motion } from 'framer-motion';
 import { useVignetteEntrance } from '@/lib/vignette-entrance-context';
+import { ProblemStack } from '@/components/vignettes/shared/ProblemStack';
+import { ProblemStateLayout } from '@/components/vignettes/shared/ProblemStateLayout';
 import Button from '@/components/Button';
 
 interface ProblemPanelProps {
   onTransition: () => void;
 }
 
-const scatteredInsights = [
+interface InsightItem {
+  id: string;
+  page: string;
+  icon: string;
+  color: string;
+  insight: string;
+}
+
+const insights: InsightItem[] = [
   {
     id: 'performance',
     page: 'Performance',
     icon: 'trending_up',
     color: '#5F3361',
     insight: 'Feedback due in 3 days',
-    // Top center, tilted left (card is 180px wide, so offset by 90px)
-    position: { top: 0, left: 'calc(50% - 90px)' },
-    rotate: -3,
-    zIndex: 1,
   },
   {
     id: 'oneOnOnes',
@@ -26,10 +32,6 @@ const scatteredInsights = [
     icon: 'people',
     color: '#10B981',
     insight: "Aisha's wellbeing dropped",
-    // Bottom left
-    position: { bottom: 0, left: '10%' },
-    rotate: 2,
-    zIndex: 2,
   },
   {
     id: 'goals',
@@ -37,10 +39,6 @@ const scatteredInsights = [
     icon: 'flag',
     color: '#FFB600',
     insight: "Malik's goal is inactive",
-    // Bottom right
-    position: { bottom: 0, right: '10%' },
-    rotate: -2,
-    zIndex: 3,
   },
 ];
 
@@ -48,100 +46,74 @@ export default function ProblemPanel({ onTransition }: ProblemPanelProps) {
   const { entranceDelay, stagger, reducedMotion } = useVignetteEntrance();
 
   // CTA appears after all cards have animated in
-  const ctaDelay = reducedMotion ? 0 : entranceDelay + scatteredInsights.length * stagger + 0.1;
+  const ctaDelay = reducedMotion ? 0 : entranceDelay + insights.length * stagger + 0.1;
+
+  const renderInsightCard = (item: InsightItem) => (
+    <>
+      {/* Window chrome header */}
+      <div className="px-3 py-2 flex items-center gap-1.5 bg-neutral-100 border-b border-border">
+        <span className="w-[6px] h-[6px] rounded-full bg-[#FF5F56]" />
+        <span className="w-[6px] h-[6px] rounded-full bg-[#FFBD2E]" />
+        <span className="w-[6px] h-[6px] rounded-full bg-[#27CA40]" />
+        <span
+          className="material-icons-outlined text-[14px] ml-1"
+          style={{ color: item.color }}
+        >
+          {item.icon}
+        </span>
+        <span className="text-caption font-semibold text-primary">
+          {item.page}
+        </span>
+      </div>
+      {/* Page content */}
+      <div className="px-3 py-3 bg-background-elevated">
+        <span className="text-body-sm text-primary leading-snug block">{item.insight}</span>
+      </div>
+    </>
+  );
 
   return (
-    <div className="relative min-h-[300px] lg:min-h-[360px] flex flex-col items-center justify-center p-4">
+    <ProblemStateLayout
+      button={
+        <Button onClick={onTransition} enterDelay={ctaDelay}>
+          Connect them
+        </Button>
+      }
+    >
       {/* Mobile: Stacked cards */}
-      <div className="flex flex-col gap-3 w-full mb-4 lg:hidden">
-        {scatteredInsights.map((item, i) => (
+      <div className="flex flex-col gap-3 w-full lg:hidden">
+        {insights.map((item, i) => (
           <motion.div
             key={item.id}
             className="w-full bg-background-elevated rounded-lg overflow-hidden border border-border-strong"
-            initial={{ opacity: 0, scale: 0.9 }}
-            animate={{ opacity: 1, scale: 1 }}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
             transition={{
               delay: reducedMotion ? 0 : entranceDelay + i * stagger,
               duration: 0.4,
               ease: 'easeOut' as const,
             }}
           >
-            {/* Window chrome header */}
-            <div className="px-3 py-2 flex items-center gap-1.5 bg-neutral-100 border-b border-border">
-              <span className="w-[6px] h-[6px] rounded-full bg-[#FF5F56]" />
-              <span className="w-[6px] h-[6px] rounded-full bg-[#FFBD2E]" />
-              <span className="w-[6px] h-[6px] rounded-full bg-[#27CA40]" />
-              <span
-                className="material-icons-outlined text-[14px] ml-1"
-                style={{ color: item.color }}
-              >
-                {item.icon}
-              </span>
-              <span className="text-caption font-semibold text-primary">
-                {item.page}
-              </span>
-            </div>
-            {/* Page content */}
-            <div className="px-3 py-3 bg-background-elevated">
-              <span className="text-body-sm text-primary leading-snug block">{item.insight}</span>
-            </div>
+            {renderInsightCard(item)}
           </motion.div>
         ))}
       </div>
 
-      {/* Desktop: Scattered page cards */}
-      <div className="relative h-[220px] w-full hidden lg:block">
-        {scatteredInsights.map((item, i) => (
-          <motion.div
-            key={item.id}
-            className="absolute w-[180px] bg-background-elevated rounded-lg overflow-hidden border border-border-strong"
-            style={{
-              top: item.position.top,
-              right: item.position.right,
-              bottom: item.position.bottom,
-              left: item.position.left,
-              zIndex: item.zIndex,
-            }}
-            initial={{ opacity: 0, scale: 0.9 }}
-            animate={{ opacity: 1, scale: 1 }}
-            transition={{
-              delay: reducedMotion ? 0 : entranceDelay + i * stagger,
-              duration: 0.4,
-              ease: 'easeOut' as const,
-            }}
-          >
-            {/* Window chrome header */}
-            <div className="px-3 py-2 flex items-center gap-1.5 bg-neutral-100 border-b border-border">
-              <span className="w-[6px] h-[6px] rounded-full bg-[#FF5F56]" />
-              <span className="w-[6px] h-[6px] rounded-full bg-[#FFBD2E]" />
-              <span className="w-[6px] h-[6px] rounded-full bg-[#27CA40]" />
-              <span
-                className="material-icons-outlined text-[14px] ml-1"
-                style={{ color: item.color }}
-              >
-                {item.icon}
-              </span>
-              <span className="text-caption font-semibold text-primary">
-                {item.page}
-              </span>
-            </div>
-            {/* Page content */}
-            <div className="px-3 py-3 bg-background-elevated">
-              <span className="text-body-sm text-primary leading-snug block">{item.insight}</span>
-            </div>
-          </motion.div>
-        ))}
+      {/* Desktop: Cascading stack */}
+      <div className="hidden lg:block w-full">
+        <ProblemStack
+          items={insights}
+          keyExtractor={(item) => item.id}
+          renderItem={renderInsightCard}
+          cardClassName="bg-background-elevated"
+          config={{
+            maxVisible: 3,
+            cardWidth: 240,
+            xOffset: 64,
+            yOffset: 32,
+          }}
+        />
       </div>
-
-      {/* CTA */}
-      <div className="flex justify-center mt-4">
-        <Button
-          onClick={onTransition}
-          enterDelay={ctaDelay}
-        >
-          Connect them
-        </Button>
-      </div>
-    </div>
+    </ProblemStateLayout>
   );
 }

--- a/src/components/vignettes/multilingual/MultilingualVignette.tsx
+++ b/src/components/vignettes/multilingual/MultilingualVignette.tsx
@@ -71,7 +71,6 @@ function MultilingualContent() {
 
   return (
     <VignetteSplit
-      compact
       title={
         <div className="space-y-4">
           <StageIndicator stage={stage} onStageChange={setStage} />

--- a/src/components/vignettes/multilingual/ProblemPanel.tsx
+++ b/src/components/vignettes/multilingual/ProblemPanel.tsx
@@ -2,89 +2,114 @@
 
 import { motion } from 'framer-motion';
 import { useVignetteEntrance } from '@/lib/vignette-entrance-context';
+import { ProblemStack } from '@/components/vignettes/shared/ProblemStack';
+import { ProblemStateLayout } from '@/components/vignettes/shared/ProblemStateLayout';
 import Button from '@/components/Button';
 
 interface ProblemPanelProps {
   onTransition: () => void;
 }
 
+interface CycleWindow {
+  code: string;
+  title: string;
+  text: string;
+}
+
 // Three separate cycles - each language has its own cycle, shown as separate "windows"
-const cycleWindows = [
+const cycleWindows: CycleWindow[] = [
   {
     code: 'fr',
     title: 'Q1 Performance Cycle (French)',
     text: "Comment cette personne a-t-elle performé au cours de cette période d'évaluation?",
-    position: { rotate: -2, x: 0 }
   },
   {
     code: 'es',
     title: 'Q1 Performance Cycle (Spanish)',
     text: '¿Cómo se desempeñó esta persona durante este período de evaluación?',
-    position: { rotate: 1, x: 0 }
   },
   {
     code: 'dv',
     title: 'Q1 Performance Cycle (Dhivehi)',
     text: 'މި މީހާ މި ރިވިއު ތެރޭގައި ކިހިނެއް ކުރިއަރައިފި؟',
-    position: { rotate: -1, x: 0 }
   }
 ];
 
 export default function ProblemPanel({ onTransition }: ProblemPanelProps) {
-  const { stagger, reducedMotion } = useVignetteEntrance();
+  const { entranceDelay, stagger, reducedMotion } = useVignetteEntrance();
+
+  const renderCycleWindow = (window: CycleWindow) => (
+    <>
+      {/* Window chrome - browser-like header */}
+      <div className="px-3 py-2 bg-black/5 border-b border-border flex items-center gap-2">
+        {/* Traffic lights */}
+        <div className="flex items-center gap-1.5">
+          <span className="w-2.5 h-2.5 rounded-full bg-[#FF5F56]" />
+          <span className="w-2.5 h-2.5 rounded-full bg-[#FFBD2E]" />
+          <span className="w-2.5 h-2.5 rounded-full bg-[#27CA40]" />
+        </div>
+        {/* Window title */}
+        <span className="text-caption font-medium text-secondary ml-2">
+          {window.title}
+        </span>
+      </div>
+
+      {/* Window content - translation field */}
+      <div className="p-3">
+        <p
+          className="text-body-sm text-primary leading-relaxed"
+          style={window.code === 'dv' ? { direction: 'rtl' } : undefined}
+        >
+          {window.text}
+        </p>
+      </div>
+    </>
+  );
+
+  const ctaDelay = entranceDelay + cycleWindows.length * stagger + 0.1;
 
   return (
-    <div className="w-full space-y-4">
-      {/* 3 separate browser-like windows stacked */}
-      <div className="p-4 flex flex-col gap-3 items-center">
+    <ProblemStateLayout
+      button={
+        <Button onClick={onTransition} enterDelay={ctaDelay}>
+          Unify them
+        </Button>
+      }
+    >
+      {/* Mobile: Stacked windows */}
+      <div className="flex flex-col gap-3 w-full lg:hidden">
         {cycleWindows.map((window, index) => (
           <motion.div
             key={window.code}
-            className="w-full max-w-[340px] bg-background-elevated rounded-lg border border-border-strong overflow-hidden"
-            style={{ willChange: 'transform, opacity' }}
-            initial={{ opacity: 0, y: 20, rotate: 0 }}
-            animate={{
-              opacity: 1,
-              y: 0,
-              rotate: reducedMotion ? 0 : window.position.rotate
-            }}
+            className="w-full max-w-[340px] mx-auto bg-background-elevated rounded-lg border border-border-strong overflow-hidden"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
             transition={{
-              type: 'spring',
-              stiffness: 300,
-              damping: 30,
-              delay: reducedMotion ? 0 : index * stagger,
+              duration: 0.4,
+              delay: reducedMotion ? 0 : entranceDelay + index * stagger,
+              ease: 'easeOut' as const,
             }}
           >
-            {/* Window chrome - browser-like header */}
-            <div className="px-3 py-2 bg-black/5 border-b border-border flex items-center gap-2">
-              {/* Traffic lights */}
-              <div className="flex items-center gap-1.5">
-                <span className="w-2.5 h-2.5 rounded-full bg-[#FF5F56]" />
-                <span className="w-2.5 h-2.5 rounded-full bg-[#FFBD2E]" />
-                <span className="w-2.5 h-2.5 rounded-full bg-[#27CA40]" />
-              </div>
-              {/* Window title */}
-              <span className="text-caption font-medium text-secondary ml-2">
-                {window.title}
-              </span>
-            </div>
-
-            {/* Window content - translation field */}
-            <div className="p-3">
-              <p
-                className="text-body-sm text-primary leading-relaxed"
-                style={window.code === 'dv' ? { direction: 'rtl' } : undefined}
-              >
-                {window.text}
-              </p>
-            </div>
+            {renderCycleWindow(window)}
           </motion.div>
         ))}
-
-        <Button onClick={onTransition}>
-          Unify them
-        </Button>
       </div>
-    </div>
+
+      {/* Desktop: Cascading stack */}
+      <div className="hidden lg:block w-full">
+        <ProblemStack
+          items={cycleWindows}
+          keyExtractor={(w) => w.code}
+          renderItem={renderCycleWindow}
+          cardClassName="bg-background-elevated"
+          config={{
+            maxVisible: 3,
+            cardWidth: 340,
+            xOffset: 40,
+            yOffset: 20,
+          }}
+        />
+      </div>
+    </ProblemStateLayout>
   );
 }

--- a/src/components/vignettes/prototyping/PrototypingVignette.tsx
+++ b/src/components/vignettes/prototyping/PrototypingVignette.tsx
@@ -33,7 +33,6 @@ function PrototypingContent() {
 
   return (
     <VignetteSplit
-      compact
       title={
         <div className="space-y-4">
           <StageIndicator stage={stage} onStageChange={setStage} />

--- a/src/components/vignettes/prototyping/SandboxPanel.tsx
+++ b/src/components/vignettes/prototyping/SandboxPanel.tsx
@@ -138,7 +138,7 @@ function LoadingState({ content }: { content: PrototypingContent }) {
 
 function SolutionState({ content }: { content: PrototypingContent }) {
   return (
-    <div className="relative w-full">
+    <div className="w-full space-y-4">
       {/* Main Sandbox Container */}
       <div className="bg-background-elevated border border-border rounded-lg p-4 w-full">
         {/* Header */}
@@ -170,12 +170,12 @@ function SolutionState({ content }: { content: PrototypingContent }) {
         </div>
       </div>
 
-      {/* Claude Code TUI Overlay */}
+      {/* Claude Code TUI */}
       <motion.div
-        initial={{ opacity: 0, y: '95%', scale: 0.95 }}
-        animate={{ opacity: 1, y: '85%', scale: 1 }}
+        initial={{ opacity: 0, y: 20, scale: 0.98 }}
+        animate={{ opacity: 1, y: 0, scale: 1 }}
         transition={{ duration: 0.3, ease: 'easeOut', delay: 0.2 }}
-        className="absolute bottom-0 right-0 left-0 sm:left-auto sm:right-4 bg-[#09090B] rounded-lg w-full sm:w-[340px] lg:w-[420px] shadow-2xl border border-[#1f1f23] overflow-hidden"
+        className="relative bg-[#09090B] rounded-lg w-full shadow-2xl border border-[#1f1f23] overflow-hidden"
       >
         {/* TUI Header */}
         <div className="bg-[#111113] px-4 py-2 rounded-t-lg border-b border-[#1f1f23] flex items-center justify-between">

--- a/src/components/vignettes/prototyping/SandboxPanel.tsx
+++ b/src/components/vignettes/prototyping/SandboxPanel.tsx
@@ -2,6 +2,8 @@
 
 import { motion, AnimatePresence } from 'framer-motion';
 import { useVignetteEntrance } from '@/lib/vignette-entrance-context';
+import { ProblemStack } from '@/components/vignettes/shared/ProblemStack';
+import { ProblemStateLayout } from '@/components/vignettes/shared/ProblemStateLayout';
 import Button from '@/components/Button';
 import type { PrototypingContent } from './content';
 
@@ -22,18 +24,24 @@ function ProblemState({
   onTransition?: () => void;
 }) {
   const { entranceDelay, stagger } = useVignetteEntrance();
-  const ctaDelay = entranceDelay + questions.length * stagger + 0.1;
+  const ctaDelay = entranceDelay + Math.min(questions.length, 5) * stagger + 0.1;
 
   return (
-    <div className="relative min-h-[280px] lg:min-h-[320px] flex flex-col items-center justify-center p-4 lg:p-8">
+    <ProblemStateLayout
+      button={
+        <Button onClick={onTransition} enterDelay={ctaDelay}>
+          See how it works
+        </Button>
+      }
+    >
       {/* Mobile: Stacked questions */}
-      <div className="flex flex-col gap-2 w-full mb-4 lg:hidden">
-        {questions.map((q, index) => (
+      <div className="flex flex-col gap-2 w-full lg:hidden">
+        {questions.slice(0, 4).map((q, index) => (
           <motion.div
             key={q.id}
             className="bg-background-elevated px-4 py-2 rounded-lg border border-border-strong text-body-sm text-secondary font-medium"
-            initial={{ opacity: 0, y: 20, scale: 0.9 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
             transition={{
               duration: 0.4,
               delay: entranceDelay + index * stagger,
@@ -45,50 +53,23 @@ function ProblemState({
         ))}
       </div>
 
-      {/* Desktop: Scattered floating questions */}
-      <div className="relative w-full h-44 hidden lg:block">
-        {questions.map((q, index) => {
-          const positions = [
-            { top: '0%', left: '5%', rotate: -2 },
-            { top: '5%', right: '8%', rotate: 2 },
-            { top: '35%', left: '25%', rotate: -1 },
-            { top: '40%', right: '20%', rotate: 1 },
-            { top: '70%', left: '8%', rotate: 2 },
-            { top: '65%', right: '5%', rotate: -2 },
-          ];
-          const pos = positions[index % positions.length];
-
-          return (
-            <motion.div
-              key={q.id}
-              className="absolute bg-background-elevated px-4 py-2 rounded-lg border border-border-strong text-body-sm text-secondary font-medium"
-              style={{
-                ...pos,
-                transform: `rotate(${pos.rotate}deg)`,
-              }}
-              initial={{ opacity: 0, y: 20, scale: 0.9 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              transition={{
-                duration: 0.4,
-                delay: entranceDelay + index * stagger,
-                ease: 'easeOut' as const,
-              }}
-            >
-              {q.text}
-            </motion.div>
-          );
-        })}
+      {/* Desktop: Cascading stack */}
+      <div className="hidden lg:block w-full">
+        <ProblemStack
+          items={questions}
+          keyExtractor={(q) => q.id}
+          renderItem={(q) => (
+            <span className="text-body-sm text-secondary font-medium line-clamp-2">{q.text}</span>
+          )}
+          config={{
+            maxVisible: 5,
+            cardWidth: 260,
+            xOffset: 56,
+            yOffset: 28,
+          }}
+        />
       </div>
-
-      {/* CTA */}
-      <Button
-        onClick={onTransition}
-        enterDelay={ctaDelay}
-        className="mt-4 lg:mt-6"
-      >
-        See how it works
-      </Button>
-    </div>
+    </ProblemStateLayout>
   );
 }
 

--- a/src/components/vignettes/shared/ProblemStack.tsx
+++ b/src/components/vignettes/shared/ProblemStack.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState, useEffect, ReactNode } from 'react';
+import { motion } from 'framer-motion';
+import { useVignetteEntrance } from '@/lib/vignette-entrance-context';
+
+interface ProblemStackConfig {
+  maxVisible?: number;
+  yOffset?: number;
+  xOffset?: number;
+  scaleStep?: number;
+  opacityStep?: number;
+  cardWidth?: number;
+}
+
+interface ProblemStackProps<T> {
+  items: T[];
+  renderItem: (item: T, index: number) => ReactNode;
+  keyExtractor: (item: T) => string;
+  config?: ProblemStackConfig;
+  className?: string;
+  cardClassName?: string;
+}
+
+const DEFAULT_CONFIG: Required<ProblemStackConfig> = {
+  maxVisible: 5,
+  yOffset: 28,
+  xOffset: 56,
+  scaleStep: 0.015,
+  opacityStep: 0.08,
+  cardWidth: 260,
+};
+
+export function ProblemStack<T>({
+  items,
+  renderItem,
+  keyExtractor,
+  config = {},
+  className = '',
+  cardClassName = '',
+}: ProblemStackProps<T>) {
+  const mergedConfig = { ...DEFAULT_CONFIG, ...config };
+  const { entranceDelay, stagger } = useVignetteEntrance();
+  const [entranceComplete, setEntranceComplete] = useState(false);
+
+  const visibleItems = items.slice(0, mergedConfig.maxVisible);
+
+  // Mark entrance complete after all cards have animated in
+  useEffect(() => {
+    const totalEntranceTime = (entranceDelay + visibleItems.length * stagger + 0.4) * 1000;
+    const timer = setTimeout(() => setEntranceComplete(true), totalEntranceTime);
+    return () => clearTimeout(timer);
+  }, [entranceDelay, stagger, visibleItems.length]);
+
+  const containerWidth = mergedConfig.cardWidth + (mergedConfig.maxVisible - 1) * mergedConfig.xOffset;
+  // Height just needs to cover the y-offset spread; cards overflow naturally
+  const containerHeight = (mergedConfig.maxVisible - 1) * mergedConfig.yOffset + 100;
+
+  return (
+    <div className={`relative mx-auto ${className}`} style={{ width: containerWidth, height: containerHeight }}>
+      {visibleItems.map((item, index) => {
+        const depth = mergedConfig.maxVisible - 1 - index;
+        const xOffset = depth * mergedConfig.xOffset;
+        const yOffset = depth * mergedConfig.yOffset;
+        const scale = 1 - depth * mergedConfig.scaleStep;
+        const opacity = 1 - depth * mergedConfig.opacityStep;
+
+        return (
+          <motion.div
+            key={keyExtractor(item)}
+            className={`absolute rounded-lg border border-border-strong shadow-sm cursor-default overflow-hidden ${cardClassName || 'bg-background-elevated px-4 py-3'}`}
+            style={{
+              width: mergedConfig.cardWidth,
+              zIndex: mergedConfig.maxVisible - depth,
+            }}
+            initial={{ opacity: 0, y: yOffset + 20, x: xOffset, scale: scale * 0.9 }}
+            animate={{
+              opacity: opacity,
+              y: yOffset,
+              x: xOffset,
+              scale: scale,
+            }}
+            whileHover={{
+              scale: 1.02,
+              y: yOffset - 8,
+              opacity: 1,
+              zIndex: 10,
+              boxShadow: '0 8px 24px rgba(0, 0, 0, 0.12)',
+            }}
+            transition={
+              entranceComplete
+                ? { duration: 0.15, ease: 'easeOut' }
+                : {
+                    duration: 0.4,
+                    delay: entranceDelay + index * stagger,
+                    ease: 'easeOut' as const,
+                  }
+            }
+          >
+            {renderItem(item, index)}
+          </motion.div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/vignettes/shared/ProblemStateLayout.tsx
+++ b/src/components/vignettes/shared/ProblemStateLayout.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { ReactNode } from 'react';
+
+interface ProblemStateLayoutProps {
+  children: ReactNode;  // The ProblemStack content
+  button: ReactNode;    // The CTA button
+}
+
+export function ProblemStateLayout({ children, button }: ProblemStateLayoutProps) {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[280px] lg:min-h-[320px] p-4 lg:p-6">
+      {/* Stack container */}
+      <div className="w-full mb-12">
+        {children}
+      </div>
+
+      {/* Button */}
+      <div className="flex justify-center">
+        {button}
+      </div>
+    </div>
+  );
+}

--- a/src/components/vignettes/vibe-coding/VibeCodingVignette.tsx
+++ b/src/components/vignettes/vibe-coding/VibeCodingVignette.tsx
@@ -16,7 +16,6 @@ export default function VibeCodingVignette() {
         {/* Section: Vibe Coding Demo */}
         <motion.div {...fadeInUp}>
           <VignetteSplit
-            compact
             title={
               <div className="space-y-4">
                 <div className="text-caption text-accent-600 font-medium">Side project</div>


### PR DESCRIPTION
## Summary

- Refactor from 2-column to single-column vignette layout for a less busy feel
- Enable left-to-right internal layout (title left, panel right) at xl breakpoints
- Unify max-width to 1280px across all page sections for consistent rhythm
- Lighten card styling: reduced opacity, blur, and shadow for a sense of ease
- Increase vertical spacing between vignettes for better visual separation
- Refactor problem states to use unified cascading stack pattern
- Fix sandbox TUI to flow naturally instead of absolute overlay

## Test plan

- [ ] Verify single column layout on desktop
- [ ] Verify horizontal (left-to-right) vignette layout at xl screens
- [ ] Check responsive behavior on tablet/mobile
- [ ] Confirm sandbox TUI displays correctly without clipping
- [ ] Verify consistent max-width alignment across header, hero, sections, footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)