### PR TITLE
Add PostHog analytics tracking

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@vercel/analytics": "^1.6.1",
         "framer-motion": "^12.23.25",
         "next": "^16.0.10",
+        "posthog-js": "^1.313.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-intersection-observer": "^10.0.0",
@@ -158,6 +159,8 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
+
+    "@posthog/core": ["@posthog/core@1.9.0", "", { "dependencies": { "cross-spawn": "^7.0.6" } }, "sha512-j7KSWxJTUtNyKynLt/p0hfip/3I46dWU2dk+pt7dKRoz2l5CYueHuHK4EO7Wlgno5yo1HO4sc4s30MXMTICHJw=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
 
@@ -381,6 +384,8 @@
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
+    "core-js": ["core-js@3.47.0", "", {}, "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
@@ -474,6 +479,8 @@
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
@@ -719,6 +726,10 @@
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
+    "posthog-js": ["posthog-js@1.313.0", "", { "dependencies": { "@posthog/core": "1.9.0", "core-js": "^3.38.1", "fflate": "^0.4.8", "preact": "^10.19.3", "web-vitals": "^4.2.4" } }, "sha512-CL8RkC7m9BTZrix86w0fdnSCVqC/gxrfs6c4Wfkz/CldFD7f2912S2KqnWFmwRVDGIwm9IR82YhublQ88gdDKw=="],
+
+    "preact": ["preact@10.28.1", "", {}, "sha512-u1/ixq/lVQI0CakKNvLDEcW5zfCjUQfZdK9qqWuIJtsezuyG6pk9TWj75GMuI/EzRSZB/VAE43sNWWZfiy8psw=="],
+
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
@@ -850,6 +861,8 @@
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
+
+    "web-vitals": ["web-vitals@4.2.4", "", {}, "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/instrumentation-client.js
+++ b/instrumentation-client.js
@@ -1,0 +1,6 @@
+import posthog from 'posthog-js'
+
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    defaults: '2025-11-30'
+});

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@vercel/analytics": "^1.6.1",
     "framer-motion": "^12.23.25",
     "next": "^16.0.10",
+    "posthog-js": "^1.313.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-intersection-observer": "^10.0.0"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,6 +3,7 @@
 import { motion } from 'framer-motion';
 import { timing, timingReduced } from '@/lib/animations';
 import { useReducedMotion } from '@/lib/useReducedMotion';
+import { trackExternalLinkClicked } from '@/lib/analytics';
 
 export default function Footer() {
   const reducedMotion = useReducedMotion();
@@ -28,6 +29,7 @@ export default function Footer() {
             target="_blank"
             rel="noopener noreferrer"
             className="btn-interactive btn-primary text-lg px-6 py-3 gap-3"
+            onClick={() => trackExternalLinkClicked('footer-linkedin', 'https://www.linkedin.com/in/idamadam/')}
           >
             Connect on
             <svg

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { heroContent } from './vignettes/hero/content';
 import { useReducedMotion } from '@/lib/useReducedMotion';
+import { trackExternalLinkClicked } from '@/lib/analytics';
 
 export default function Header() {
   const reducedMotion = useReducedMotion();
@@ -53,6 +54,7 @@ export default function Header() {
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center hover-linkedin transition-colors duration-200"
+              onClick={() => trackExternalLinkClicked('header-linkedin', 'https://www.linkedin.com/in/idamadam/')}
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/src/components/vignettes/VignetteStaged.tsx
+++ b/src/components/vignettes/VignetteStaged.tsx
@@ -3,6 +3,7 @@
 import { ReactNode, useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { VignetteStageProvider, useVignetteStage, VignetteStage } from '@/lib/vignette-stage-context';
+import type { VignetteId } from '@/lib/analytics';
 import { timing, timingReduced } from '@/lib/animations';
 import { useReducedMotion } from '@/lib/useReducedMotion';
 import Button from '@/components/Button';
@@ -17,6 +18,7 @@ interface VignetteStagedProps {
   };
   designNotesPanel?: ReactNode;
   className?: string;
+  vignetteId: VignetteId;
 }
 
 function VignetteStagedInner({
@@ -131,7 +133,7 @@ function VignetteStagedInner({
 
 export default function VignetteStaged(props: VignetteStagedProps) {
   return (
-    <VignetteStageProvider initialStage="problem">
+    <VignetteStageProvider initialStage="problem" vignetteId={props.vignetteId}>
       <VignetteStagedInner {...props} />
     </VignetteStageProvider>
   );

--- a/src/components/vignettes/ai-highlights/AIHighlightsVignette.tsx
+++ b/src/components/vignettes/ai-highlights/AIHighlightsVignette.tsx
@@ -99,7 +99,7 @@ export default function AIHighlightsVignette() {
     <VignetteContainer id="ai-highlights" allowOverflow>
       <div className="w-full space-y-10 lg:space-y-12">
         <motion.div {...fadeInUp}>
-          <VignetteStaged stages={aiHighlightsContent.stages}>
+          <VignetteStaged stages={aiHighlightsContent.stages} vignetteId="ai-highlights">
             <AIHighlightsContent />
           </VignetteStaged>
         </motion.div>

--- a/src/components/vignettes/ai-suggestions/AISuggestionsVignette.tsx
+++ b/src/components/vignettes/ai-suggestions/AISuggestionsVignette.tsx
@@ -97,7 +97,7 @@ export default function AISuggestionsVignette() {
     <VignetteContainer id="ai-suggestions" allowOverflow>
       <div className="w-full space-y-10 lg:space-y-12">
         <motion.div {...fadeInUp}>
-          <VignetteStaged stages={aiSuggestionsContent.stages}>
+          <VignetteStaged stages={aiSuggestionsContent.stages} vignetteId="ai-suggestions">
             <AISuggestionsContent />
           </VignetteStaged>
         </motion.div>

--- a/src/components/vignettes/home-connect/HomeConnectVignette.tsx
+++ b/src/components/vignettes/home-connect/HomeConnectVignette.tsx
@@ -37,7 +37,7 @@ export default function HomeConnectVignette() {
     <VignetteContainer id="home-connect" allowOverflow>
       <div className="w-full space-y-10 lg:space-y-12">
         <motion.div {...fadeInUp}>
-          <VignetteStaged stages={homeConnectContent.stages}>
+          <VignetteStaged stages={homeConnectContent.stages} vignetteId="home-connect">
             <HomeConnectContent
               notes={homeConnectContent.designNotes.notes}
               highlightedSection={highlightedSection}

--- a/src/components/vignettes/multilingual/MultilingualVignette.tsx
+++ b/src/components/vignettes/multilingual/MultilingualVignette.tsx
@@ -141,7 +141,7 @@ export default function MultilingualVignette() {
     <VignetteContainer id="multilingual" allowOverflow>
       <div className="w-full space-y-10 lg:space-y-12">
         <motion.div {...fadeInUp}>
-          <VignetteStaged stages={multilingualContent.stages}>
+          <VignetteStaged stages={multilingualContent.stages} vignetteId="multilingual">
             <MultilingualContent />
           </VignetteStaged>
         </motion.div>

--- a/src/components/vignettes/prototyping/PrototypingVignette.tsx
+++ b/src/components/vignettes/prototyping/PrototypingVignette.tsx
@@ -59,7 +59,7 @@ export default function PrototypingVignette() {
     <VignetteContainer id="prototyping">
       <div className="w-full space-y-10 lg:space-y-12">
         <motion.div {...fadeInUp}>
-          <VignetteStaged stages={prototypingContent.stages}>
+          <VignetteStaged stages={prototypingContent.stages} vignetteId="prototyping">
             <PrototypingContent />
           </VignetteStaged>
         </motion.div>

--- a/src/components/vignettes/shared/DesignNotesOverlay.tsx
+++ b/src/components/vignettes/shared/DesignNotesOverlay.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { motion } from 'framer-motion';
 import type { DesignNote } from '@/components/vignettes/types';
 import { MobileDesignNotesSheet } from './MobileDesignNotesSheet';
+import { useVignetteStage } from '@/lib/vignette-stage-context';
 
 interface DesignNotesOverlayProps {
   notes: DesignNote[];
@@ -11,6 +12,7 @@ interface DesignNotesOverlayProps {
 }
 
 export function DesignNotesOverlay({ notes, onActiveNoteChange }: DesignNotesOverlayProps) {
+  const { vignetteId } = useVignetteStage();
   const [mobileSheetOpen, setMobileSheetOpen] = useState(false);
   const [mobileIndex, setMobileIndex] = useState(0);
 
@@ -55,6 +57,7 @@ export function DesignNotesOverlay({ notes, onActiveNoteChange }: DesignNotesOve
         notes={notes}
         currentIndex={mobileIndex}
         onIndexChange={handleMobileIndexChange}
+        vignetteId={vignetteId}
       />
     </>
   );

--- a/src/components/vignettes/shared/MobileDesignNotesSheet.tsx
+++ b/src/components/vignettes/shared/MobileDesignNotesSheet.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence, PanInfo } from 'framer-motion';
 import type { DesignNote } from '@/components/vignettes/types';
+import { trackDesignNoteViewed, type VignetteId } from '@/lib/analytics';
 
 interface MobileDesignNotesSheetProps {
   isOpen: boolean;
@@ -11,6 +12,7 @@ interface MobileDesignNotesSheetProps {
   notes: DesignNote[];
   currentIndex: number;
   onIndexChange: (index: number) => void;
+  vignetteId: VignetteId;
 }
 
 export function MobileDesignNotesSheet({
@@ -19,16 +21,26 @@ export function MobileDesignNotesSheet({
   notes,
   currentIndex,
   onIndexChange,
+  vignetteId,
 }: MobileDesignNotesSheetProps) {
   const currentNote = notes[currentIndex];
   const [isDragging, setIsDragging] = useState(false);
   const [mounted, setMounted] = useState(false);
+  const trackedNotesRef = useRef<Set<string>>(new Set());
 
   // Track mount state for portal (SSR safety)
   useEffect(() => {
     setMounted(true);
     return () => setMounted(false);
   }, []);
+
+  // Track design note views (only once per note per session)
+  useEffect(() => {
+    if (isOpen && currentNote && !trackedNotesRef.current.has(currentNote.id)) {
+      trackDesignNoteViewed(vignetteId, currentNote.id);
+      trackedNotesRef.current.add(currentNote.id);
+    }
+  }, [isOpen, currentNote, vignetteId]);
 
   // Keyboard navigation
   useEffect(() => {

--- a/src/components/vignettes/shared/SectionMarker.tsx
+++ b/src/components/vignettes/shared/SectionMarker.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 import * as Popover from '@radix-ui/react-popover';
+import { useVignetteStage } from '@/lib/vignette-stage-context';
+import { trackDesignNoteViewed } from '@/lib/analytics';
 
 interface SectionMarkerProps {
   index: number;
@@ -14,10 +16,14 @@ interface SectionMarkerProps {
 
 export function SectionMarker({ index, noteId, side, isActive, onOpenChange, note }: SectionMarkerProps) {
   const [open, setOpen] = useState(false);
+  const { vignetteId } = useVignetteStage();
 
   const handleOpenChange = (isOpen: boolean) => {
     setOpen(isOpen);
     onOpenChange(noteId, isOpen);
+    if (isOpen) {
+      trackDesignNoteViewed(vignetteId, noteId);
+    }
   };
 
   return (

--- a/src/components/vignettes/vibe-coding/DemoCreationFlow.tsx
+++ b/src/components/vignettes/vibe-coding/DemoCreationFlow.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { trackExternalLinkClicked } from '@/lib/analytics';
 
 // Global styles for animated gradient border
 function GradientBorderStyles() {
@@ -294,6 +295,7 @@ export default function DemoCreationFlow({ onComplete }: DemoCreationFlowProps) 
                 rel="noopener noreferrer"
                 className="btn-interactive btn-primary animate-fadeIn"
                 style={{ animation: 'fadeIn 0.5s ease-in-out' }}
+                onClick={() => trackExternalLinkClicked('vibe-coding-waitlist', 'https://studio.up.railway.app/')}
               >
                 Join the waitlist
               </a>
@@ -439,6 +441,7 @@ export default function DemoCreationFlow({ onComplete }: DemoCreationFlowProps) 
                   target="_blank"
                   rel="noopener noreferrer"
                   className="btn-interactive btn-primary"
+                  onClick={() => trackExternalLinkClicked('vibe-coding-waitlist', 'https://studio.up.railway.app/')}
                 >
                   Join the waitlist
                 </a>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,32 @@
+import posthog from 'posthog-js';
+
+export type VignetteId =
+  | 'ai-highlights'
+  | 'ai-suggestions'
+  | 'prototyping'
+  | 'multilingual'
+  | 'home-connect'
+  | 'vibe-coding';
+
+export type VignetteStage = 'solution' | 'designNotes';
+
+export function trackVignetteInteracted(vignetteId: VignetteId, stage: VignetteStage) {
+  posthog.capture('vignette_interacted', {
+    vignette_id: vignetteId,
+    stage,
+  });
+}
+
+export function trackDesignNoteViewed(vignetteId: VignetteId, noteId: string) {
+  posthog.capture('design_note_viewed', {
+    vignette_id: vignetteId,
+    note_id: noteId,
+  });
+}
+
+export function trackExternalLinkClicked(linkId: string, destinationUrl: string) {
+  posthog.capture('external_link_clicked', {
+    link_id: linkId,
+    destination_url: destinationUrl,
+  });
+}

--- a/src/lib/vignette-stage-context.tsx
+++ b/src/lib/vignette-stage-context.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+import { trackVignetteInteracted, type VignetteId } from './analytics';
 
 export type VignetteStage = 'problem' | 'solution' | 'designNotes';
 
@@ -11,6 +12,7 @@ interface VignetteStageContextValue {
   goToDesignNotes: () => void;
   reset: () => void;
   hasSeenSolution: boolean;
+  vignetteId: VignetteId;
 }
 
 const VignetteStageContext = createContext<VignetteStageContextValue | null>(null);
@@ -18,11 +20,13 @@ const VignetteStageContext = createContext<VignetteStageContextValue | null>(nul
 interface VignetteStageProviderProps {
   children: ReactNode;
   initialStage?: VignetteStage;
+  vignetteId: VignetteId;
 }
 
 export function VignetteStageProvider({
   children,
-  initialStage = 'problem'
+  initialStage = 'problem',
+  vignetteId,
 }: VignetteStageProviderProps) {
   const [stage, setStageInternal] = useState<VignetteStage>(initialStage);
   const [hasSeenSolution, setHasSeenSolution] = useState(initialStage === 'solution' || initialStage === 'designNotes');
@@ -39,13 +43,15 @@ export function VignetteStageProvider({
 
   const goToSolution = useCallback(() => {
     setStage('solution');
-  }, [setStage]);
+    trackVignetteInteracted(vignetteId, 'solution');
+  }, [setStage, vignetteId]);
 
   const goToDesignNotes = useCallback(() => {
     if (hasSeenSolution) {
       setStage('designNotes');
+      trackVignetteInteracted(vignetteId, 'designNotes');
     }
-  }, [hasSeenSolution, setStage]);
+  }, [hasSeenSolution, setStage, vignetteId]);
 
   const reset = useCallback(() => {
     setStageInternal('problem');
@@ -61,6 +67,7 @@ export function VignetteStageProvider({
         goToDesignNotes,
         reset,
         hasSeenSolution,
+        vignetteId,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- Add posthog-js for analytics tracking
- Implement 3 core events to understand visitor engagement depth:
  - `vignette_interacted`: tracks when users progress to solution or designNotes stages
  - `design_note_viewed`: tracks annotation views on desktop (markers) and mobile (sheet)
  - `external_link_clicked`: tracks LinkedIn and waitlist link clicks

## Test plan
- [ ] Verify PostHog events fire in browser devtools network tab
- [ ] Test vignette stage transitions trigger `vignette_interacted`
- [ ] Test design note markers (desktop) trigger `design_note_viewed`
- [ ] Test mobile design notes sheet triggers `design_note_viewed`
- [ ] Test external links (header, footer, vibe-coding) trigger `external_link_clicked`

🤖 Generated with [Claude Code](https://claude.com/claude-code)