### PR TITLE
Add PostHog survey trigger on vignette engagement

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -10,11 +10,23 @@ export type VignetteId =
 
 export type VignetteStage = 'solution' | 'designNotes';
 
+const SOLUTION_VIEW_THRESHOLD = 3;
+let solutionViewCount = 0;
+let surveyEventFired = false;
+
 export function trackVignetteInteracted(vignetteId: VignetteId, stage: VignetteStage) {
   posthog.capture('vignette_interacted', {
     vignette_id: vignetteId,
     stage,
   });
+
+  if (stage === 'solution') {
+    solutionViewCount++;
+    if (solutionViewCount >= SOLUTION_VIEW_THRESHOLD && !surveyEventFired) {
+      surveyEventFired = true;
+      posthog.capture('portfolio_feedback_ready');
+    }
+  }
 }
 
 export function trackDesignNoteViewed(vignetteId: VignetteId, noteId: string) {


### PR DESCRIPTION
## Summary
- Fires `portfolio_feedback_ready` event after user views 3 vignette solutions
- Configure PostHog survey to trigger on this event for feedback collection

## Setup in PostHog
1. Create survey with questions:
   - "What stood out to you?" (open text)
   - "Anything you expected to see but didn't?" (optional)
2. Set trigger: Event → `portfolio_feedback_ready`
3. Enable "Show only once per user"

## Test plan
- [ ] Click through 3 vignettes to solution stage
- [ ] Verify `portfolio_feedback_ready` event fires in PostHog
- [ ] Confirm survey displays after event

🤖 Generated with [Claude Code](https://claude.com/claude-code)