### PR TITLE
Remove PostHog survey trigger event

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -10,23 +10,11 @@ export type VignetteId =
 
 export type VignetteStage = 'solution' | 'designNotes';
 
-const SOLUTION_VIEW_THRESHOLD = 3;
-let solutionViewCount = 0;
-let surveyEventFired = false;
-
 export function trackVignetteInteracted(vignetteId: VignetteId, stage: VignetteStage) {
   posthog.capture('vignette_interacted', {
     vignette_id: vignetteId,
     stage,
   });
-
-  if (stage === 'solution') {
-    solutionViewCount++;
-    if (solutionViewCount >= SOLUTION_VIEW_THRESHOLD && !surveyEventFired) {
-      surveyEventFired = true;
-      posthog.capture('portfolio_feedback_ready');
-    }
-  }
 }
 
 export function trackDesignNoteViewed(vignetteId: VignetteId, noteId: string) {


### PR DESCRIPTION
## Summary
- Remove `portfolio_feedback_ready` event trigger from analytics
- Going with manual Google Form distribution to trusted contacts instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)