### PR TITLE
Fix UI issues: tooltip z-index, marker visibility, and content updates

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "portfolio-nextjs",
       "dependencies": {
         "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "@vercel/analytics": "^1.6.1",
         "framer-motion": "^12.23.25",
         "next": "^16.0.10",
@@ -190,6 +191,8 @@
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
+    "@radix-ui/react-tooltip": ["@radix-ui/react-tooltip@1.2.8", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg=="],
+
     "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
 
     "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.2", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg=="],
@@ -203,6 +206,8 @@
     "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.1", "", { "dependencies": { "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w=="],
 
     "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ=="],
+
+    "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@vercel/analytics": "^1.6.1",
     "framer-motion": "^12.23.25",
     "next": "^16.0.10",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -542,6 +542,40 @@ a {
   }
 }
 
+/* =================================================
+   TOOLTIP ANIMATIONS
+   Used by Radix UI Tooltip via data-state attributes
+   ================================================= */
+@keyframes tooltip-in {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes tooltip-out {
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+}
+
+.animate-tooltip-in {
+  animation: tooltip-in 0.18s cubic-bezier(0.25, 0.1, 0.25, 1);
+}
+
+.animate-tooltip-out {
+  animation: tooltip-out 0.15s cubic-bezier(0.25, 0.1, 0.25, 1);
+}
+
 /* Layout utility classes */
 .case-study-container {
   min-height: 100vh;

--- a/src/components/vignettes/ai-highlights/HighlightsPanel.tsx
+++ b/src/components/vignettes/ai-highlights/HighlightsPanel.tsx
@@ -5,7 +5,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useReducedMotion } from '@/lib/useReducedMotion';
 import { useIntroSequence } from '@/lib/intro-sequence-context';
 import NumberedMarker from './NumberedMarker';
-import DesktopMarkerTooltip from '../shared/DesktopMarkerTooltip';
+import MarkerTooltip from '../shared/MarkerTooltip';
 import { aiHighlightsContent, FeedbackSource } from './content';
 
 interface HighlightsPanelProps {
@@ -256,19 +256,20 @@ function SolutionState({
             onMouseEnter={() => onMarkerHover?.(1)}
             onMouseLeave={() => onMarkerHover?.(null)}
           >
-            <NumberedMarker
-              number={1}
-              onClick={() => onMarkerClick?.(1)}
-              isActive={highlightedSection === 1}
-              hasBeenDiscovered={markersDiscovered}
-              onDiscover={() => setMarkersDiscovered(true)}
-            />
-            <DesktopMarkerTooltip
+            <MarkerTooltip
               number={1}
               text={aiHighlightsContent.designDetails[0].text}
               isVisible={highlightedSection === 1}
-              position="left"
-            />
+              side="left"
+            >
+              <NumberedMarker
+                number={1}
+                onClick={() => onMarkerClick?.(1)}
+                isActive={highlightedSection === 1}
+                hasBeenDiscovered={markersDiscovered}
+                onDiscover={() => setMarkersDiscovered(true)}
+              />
+            </MarkerTooltip>
           </motion.div>
           <motion.div
             className="absolute -left-4 top-1/2 -translate-y-1/2 xl:hidden"
@@ -320,19 +321,20 @@ function SolutionState({
             onMouseEnter={() => onMarkerHover?.(2)}
             onMouseLeave={() => onMarkerHover?.(null)}
           >
-            <NumberedMarker
-              number={2}
-              onClick={() => onMarkerClick?.(2)}
-              isActive={highlightedSection === 2}
-              hasBeenDiscovered={markersDiscovered}
-              onDiscover={() => setMarkersDiscovered(true)}
-            />
-            <DesktopMarkerTooltip
+            <MarkerTooltip
               number={2}
               text={aiHighlightsContent.designDetails[1].text}
               isVisible={highlightedSection === 2}
-              position="left"
-            />
+              side="left"
+            >
+              <NumberedMarker
+                number={2}
+                onClick={() => onMarkerClick?.(2)}
+                isActive={highlightedSection === 2}
+                hasBeenDiscovered={markersDiscovered}
+                onDiscover={() => setMarkersDiscovered(true)}
+              />
+            </MarkerTooltip>
           </motion.div>
           <motion.div
             className="absolute -left-4 top-8 xl:hidden"
@@ -459,19 +461,20 @@ function SolutionState({
                   onMouseEnter={() => onMarkerHover?.(3)}
                   onMouseLeave={() => onMarkerHover?.(null)}
                 >
-                  <NumberedMarker
-                    number={3}
-                    onClick={() => onMarkerClick?.(3)}
-                    isActive={highlightedSection === 3}
-                    hasBeenDiscovered={markersDiscovered}
-                    onDiscover={() => setMarkersDiscovered(true)}
-                  />
-                  <DesktopMarkerTooltip
+                  <MarkerTooltip
                     number={3}
                     text={aiHighlightsContent.designDetails[2].text}
                     isVisible={highlightedSection === 3}
-                    position="right"
-                  />
+                    side="right"
+                  >
+                    <NumberedMarker
+                      number={3}
+                      onClick={() => onMarkerClick?.(3)}
+                      isActive={highlightedSection === 3}
+                      hasBeenDiscovered={markersDiscovered}
+                      onDiscover={() => setMarkersDiscovered(true)}
+                    />
+                  </MarkerTooltip>
                 </motion.div>
                 <motion.div
                   className="xl:hidden"

--- a/src/components/vignettes/ai-highlights/NumberedMarker.tsx
+++ b/src/components/vignettes/ai-highlights/NumberedMarker.tsx
@@ -1,66 +1,74 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, forwardRef } from 'react';
 import { motion } from 'framer-motion';
 import { useReducedMotion } from '@/lib/useReducedMotion';
 
 interface NumberedMarkerProps {
   number: number;
-  onClick?: () => void;
+  onClick?: (e?: React.MouseEvent) => void;
   isActive?: boolean;
   className?: string;
   hasBeenDiscovered?: boolean;
   onDiscover?: () => void;
 }
 
-export default function NumberedMarker({
-  number,
-  onClick,
-  isActive = false,
-  className = '',
-  hasBeenDiscovered = false,
-  onDiscover,
-}: NumberedMarkerProps) {
-  const [shouldAnimate, setShouldAnimate] = useState(false);
-  const prefersReducedMotion = useReducedMotion();
+const NumberedMarker = forwardRef<HTMLButtonElement, NumberedMarkerProps>(
+  function NumberedMarker(
+    {
+      number,
+      onClick,
+      isActive = false,
+      className = '',
+      hasBeenDiscovered = false,
+      onDiscover,
+      ...props
+    },
+    ref
+  ) {
+    const [shouldAnimate, setShouldAnimate] = useState(false);
+    const prefersReducedMotion = useReducedMotion();
 
-  // Start subtle animation after delay (user has had time to scan content)
-  useEffect(() => {
-    if (prefersReducedMotion || hasBeenDiscovered) {
+    // Start subtle animation after delay (user has had time to scan content)
+    useEffect(() => {
+      if (prefersReducedMotion || hasBeenDiscovered) {
+        setShouldAnimate(false);
+        return;
+      }
+      const timer = setTimeout(() => setShouldAnimate(true), 1500);
+      return () => clearTimeout(timer);
+    }, [prefersReducedMotion, hasBeenDiscovered]);
+
+    const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
       setShouldAnimate(false);
-      return;
-    }
-    const timer = setTimeout(() => setShouldAnimate(true), 1500);
-    return () => clearTimeout(timer);
-  }, [prefersReducedMotion, hasBeenDiscovered]);
+      onDiscover?.();
+      onClick?.(e);
+    };
 
-  const handleClick = () => {
-    setShouldAnimate(false);
-    onDiscover?.();
-    onClick?.();
-  };
+    return (
+      <motion.button
+        ref={ref}
+        type="button"
+        onClick={handleClick}
+        className={`
+          flex items-center justify-center
+          size-8 rounded-full
+          bg-white border border-accent-300 shadow-sm
+          text-accent-600 text-[13px] font-medium
+          cursor-pointer
+          transition-all duration-200
+          hover:bg-accent-50 hover:border-accent-400 hover:text-accent-700
+          focus:outline-none focus:ring-2 focus:ring-accent-400 focus:ring-offset-2
+          ${isActive ? 'bg-accent-50 border-accent-400' : ''}
+          ${shouldAnimate ? 'breathe-glow' : ''}
+          ${className}
+        `}
+        {...props}
+      >
+        {number}
+      </motion.button>
+    );
+  }
+);
 
-  return (
-    <motion.button
-      type="button"
-      onClick={handleClick}
-      className={`
-        flex items-center justify-center
-        size-8 rounded-full
-        bg-white border border-accent-300 shadow-sm
-        text-accent-600 text-[13px] font-medium
-        cursor-pointer
-        transition-all duration-200
-        hover:bg-accent-50 hover:border-accent-400 hover:text-accent-700
-        focus:outline-none focus:ring-2 focus:ring-accent-400 focus:ring-offset-2
-        ${isActive ? 'bg-accent-50 border-accent-400' : ''}
-        ${shouldAnimate ? 'breathe-glow' : ''}
-        ${className}
-      `}
-      whileHover={{ scale: 1.1 }}
-      whileTap={{ scale: 0.95 }}
-    >
-      {number}
-    </motion.button>
-  );
-}
+export default NumberedMarker;

--- a/src/components/vignettes/ai-suggestions/SuggestionsPanel.tsx
+++ b/src/components/vignettes/ai-suggestions/SuggestionsPanel.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import RichTextEditor from '@/components/demos/RichTextEditor';
 import NumberedMarker from '../ai-highlights/NumberedMarker';
-import DesktopMarkerTooltip from '../shared/DesktopMarkerTooltip';
+import MarkerTooltip from '../shared/MarkerTooltip';
 import { useReducedMotion } from '@/lib/useReducedMotion';
 import { useIntroSequence } from '@/lib/intro-sequence-context';
 import type { AISuggestionsContent } from './content';
@@ -147,19 +147,20 @@ function RecommendationsPanel({
               onMouseEnter={() => onMarkerHover?.(2)}
               onMouseLeave={() => onMarkerHover?.(null)}
             >
-              <NumberedMarker
-                number={2}
-                onClick={() => onMarkerClick?.(2)}
-                isActive={highlightedSection === 2}
-                hasBeenDiscovered={markersDiscovered}
-                onDiscover={onMarkersDiscover}
-              />
-              <DesktopMarkerTooltip
+              <MarkerTooltip
                 number={2}
                 text={content.designDetails[1].text}
                 isVisible={highlightedSection === 2}
-                position="left"
-              />
+                side="left"
+              >
+                <NumberedMarker
+                  number={2}
+                  onClick={() => onMarkerClick?.(2)}
+                  isActive={highlightedSection === 2}
+                  hasBeenDiscovered={markersDiscovered}
+                  onDiscover={onMarkersDiscover}
+                />
+              </MarkerTooltip>
             </motion.div>
             <motion.div
               key="marker-2-mobile"
@@ -220,19 +221,20 @@ function RecommendationsPanel({
                   onMouseEnter={() => onMarkerHover?.(3)}
                   onMouseLeave={() => onMarkerHover?.(null)}
                 >
-                  <NumberedMarker
-                    number={3}
-                    onClick={() => onMarkerClick?.(3)}
-                    isActive={highlightedSection === 3}
-                    hasBeenDiscovered={markersDiscovered}
-                    onDiscover={onMarkersDiscover}
-                  />
-                  <DesktopMarkerTooltip
+                  <MarkerTooltip
                     number={3}
                     text={content.designDetails[2].text}
                     isVisible={highlightedSection === 3}
-                    position="right"
-                  />
+                    side="right"
+                  >
+                    <NumberedMarker
+                      number={3}
+                      onClick={() => onMarkerClick?.(3)}
+                      isActive={highlightedSection === 3}
+                      hasBeenDiscovered={markersDiscovered}
+                      onDiscover={onMarkersDiscover}
+                    />
+                  </MarkerTooltip>
                 </motion.div>
                 <motion.div
                   key="marker-3-mobile"
@@ -354,19 +356,20 @@ export default function SuggestionsPanel({
                 onMouseEnter={() => onMarkerHover?.(1)}
                 onMouseLeave={() => onMarkerHover?.(null)}
               >
-                <NumberedMarker
-                  number={1}
-                  onClick={() => onMarkerClick?.(1)}
-                  isActive={highlightedSection === 1}
-                  hasBeenDiscovered={markersDiscovered}
-                  onDiscover={() => setMarkersDiscovered(true)}
-                />
-                <DesktopMarkerTooltip
+                <MarkerTooltip
                   number={1}
                   text={content.designDetails[0].text}
                   isVisible={highlightedSection === 1}
-                  position="left"
-                />
+                  side="left"
+                >
+                  <NumberedMarker
+                    number={1}
+                    onClick={() => onMarkerClick?.(1)}
+                    isActive={highlightedSection === 1}
+                    hasBeenDiscovered={markersDiscovered}
+                    onDiscover={() => setMarkersDiscovered(true)}
+                  />
+                </MarkerTooltip>
               </motion.div>
               <motion.div
                 key="marker-1-mobile"

--- a/src/components/vignettes/home-connect/HomeConnectPanel.tsx
+++ b/src/components/vignettes/home-connect/HomeConnectPanel.tsx
@@ -3,7 +3,7 @@
 import { motion, AnimatePresence } from 'framer-motion';
 import React from 'react';
 import NumberedMarker from '../ai-highlights/NumberedMarker';
-import DesktopMarkerTooltip from '../shared/DesktopMarkerTooltip';
+import MarkerTooltip from '../shared/MarkerTooltip';
 import { homeConnectContent } from './content';
 
 interface HomeConnectPanelProps {
@@ -218,19 +218,20 @@ export default function HomeConnectPanel({
                 onMouseEnter={() => onMarkerHover?.(1)}
                 onMouseLeave={() => onMarkerHover?.(null)}
               >
-                <NumberedMarker
-                  number={1}
-                  onClick={() => onMarkerClick?.(1)}
-                  isActive={highlightedSection === 1}
-                  hasBeenDiscovered={markersDiscovered}
-                  onDiscover={() => setMarkersDiscovered(true)}
-                />
-                <DesktopMarkerTooltip
+                <MarkerTooltip
                   number={1}
                   text={homeConnectContent.designDetails[0].text}
                   isVisible={highlightedSection === 1}
-                  position="right"
-                />
+                  side="right"
+                >
+                  <NumberedMarker
+                    number={1}
+                    onClick={() => onMarkerClick?.(1)}
+                    isActive={highlightedSection === 1}
+                    hasBeenDiscovered={markersDiscovered}
+                    onDiscover={() => setMarkersDiscovered(true)}
+                  />
+                </MarkerTooltip>
               </motion.div>
               <motion.div
                 key="marker-1-mobile"
@@ -281,19 +282,20 @@ export default function HomeConnectPanel({
                     onMouseEnter={() => onMarkerHover?.(2)}
                     onMouseLeave={() => onMarkerHover?.(null)}
                   >
-                    <NumberedMarker
-                      number={2}
-                      onClick={() => onMarkerClick?.(2)}
-                      isActive={highlightedSection === 2}
-                      hasBeenDiscovered={markersDiscovered}
-                      onDiscover={() => setMarkersDiscovered(true)}
-                    />
-                    <DesktopMarkerTooltip
+                    <MarkerTooltip
                       number={2}
                       text={homeConnectContent.designDetails[1].text}
                       isVisible={highlightedSection === 2}
-                      position="left"
-                    />
+                      side="left"
+                    >
+                      <NumberedMarker
+                        number={2}
+                        onClick={() => onMarkerClick?.(2)}
+                        isActive={highlightedSection === 2}
+                        hasBeenDiscovered={markersDiscovered}
+                        onDiscover={() => setMarkersDiscovered(true)}
+                      />
+                    </MarkerTooltip>
                   </motion.div>
                   <motion.div
                     key="marker-2-mobile"
@@ -387,19 +389,20 @@ export default function HomeConnectPanel({
                     onMouseEnter={() => onMarkerHover?.(3)}
                     onMouseLeave={() => onMarkerHover?.(null)}
                   >
-                    <NumberedMarker
-                      number={3}
-                      onClick={() => onMarkerClick?.(3)}
-                      isActive={highlightedSection === 3}
-                      hasBeenDiscovered={markersDiscovered}
-                      onDiscover={() => setMarkersDiscovered(true)}
-                    />
-                    <DesktopMarkerTooltip
+                    <MarkerTooltip
                       number={3}
                       text={homeConnectContent.designDetails[2].text}
                       isVisible={highlightedSection === 3}
-                      position="right"
-                    />
+                      side="right"
+                    >
+                      <NumberedMarker
+                        number={3}
+                        onClick={() => onMarkerClick?.(3)}
+                        isActive={highlightedSection === 3}
+                        hasBeenDiscovered={markersDiscovered}
+                        onDiscover={() => setMarkersDiscovered(true)}
+                      />
+                    </MarkerTooltip>
                   </motion.div>
                   <motion.div
                     key="marker-3-mobile"

--- a/src/components/vignettes/multilingual/TranslationManagementPanel.tsx
+++ b/src/components/vignettes/multilingual/TranslationManagementPanel.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import RichTextEditor from '@/components/demos/RichTextEditor';
 import NumberedMarker from '../ai-highlights/NumberedMarker';
-import DesktopMarkerTooltip from '../shared/DesktopMarkerTooltip';
+import MarkerTooltip from '../shared/MarkerTooltip';
 import { multilingualContent } from '@/components/vignettes/multilingual/content';
 
 interface TranslationManagementPanelProps {
@@ -96,19 +96,20 @@ export default function TranslationManagementPanel({
                   onMouseEnter={() => onMarkerHover?.(1)}
                   onMouseLeave={() => onMarkerHover?.(null)}
                 >
-                  <NumberedMarker
-                    number={1}
-                    onClick={() => onMarkerClick?.(1)}
-                    isActive={highlightedSection === 1}
-                    hasBeenDiscovered={markersDiscovered}
-                    onDiscover={() => setMarkersDiscovered(true)}
-                  />
-                  <DesktopMarkerTooltip
+                  <MarkerTooltip
                     number={1}
                     text={content.designDetails[0].text}
                     isVisible={highlightedSection === 1}
-                    position="left"
-                  />
+                    side="left"
+                  >
+                    <NumberedMarker
+                      number={1}
+                      onClick={() => onMarkerClick?.(1)}
+                      isActive={highlightedSection === 1}
+                      hasBeenDiscovered={markersDiscovered}
+                      onDiscover={() => setMarkersDiscovered(true)}
+                    />
+                  </MarkerTooltip>
                 </motion.div>
                 <motion.div
                   key="marker-1-mobile"
@@ -197,19 +198,20 @@ export default function TranslationManagementPanel({
                   onMouseEnter={() => onMarkerHover?.(2)}
                   onMouseLeave={() => onMarkerHover?.(null)}
                 >
-                  <NumberedMarker
-                    number={2}
-                    onClick={() => onMarkerClick?.(2)}
-                    isActive={highlightedSection === 2}
-                    hasBeenDiscovered={markersDiscovered}
-                    onDiscover={() => setMarkersDiscovered(true)}
-                  />
-                  <DesktopMarkerTooltip
+                  <MarkerTooltip
                     number={2}
                     text={content.designDetails[1].text}
                     isVisible={highlightedSection === 2}
-                    position="right"
-                  />
+                    side="right"
+                  >
+                    <NumberedMarker
+                      number={2}
+                      onClick={() => onMarkerClick?.(2)}
+                      isActive={highlightedSection === 2}
+                      hasBeenDiscovered={markersDiscovered}
+                      onDiscover={() => setMarkersDiscovered(true)}
+                    />
+                  </MarkerTooltip>
                 </motion.div>
                 <motion.div
                   key="marker-2-mobile"
@@ -268,19 +270,20 @@ export default function TranslationManagementPanel({
                   onMouseEnter={() => onMarkerHover?.(3)}
                   onMouseLeave={() => onMarkerHover?.(null)}
                 >
-                  <NumberedMarker
-                    number={3}
-                    onClick={() => onMarkerClick?.(3)}
-                    isActive={highlightedSection === 3}
-                    hasBeenDiscovered={markersDiscovered}
-                    onDiscover={() => setMarkersDiscovered(true)}
-                  />
-                  <DesktopMarkerTooltip
+                  <MarkerTooltip
                     number={3}
                     text={content.designDetails[2].text}
                     isVisible={highlightedSection === 3}
-                    position="right"
-                  />
+                    side="right"
+                  >
+                    <NumberedMarker
+                      number={3}
+                      onClick={() => onMarkerClick?.(3)}
+                      isActive={highlightedSection === 3}
+                      hasBeenDiscovered={markersDiscovered}
+                      onDiscover={() => setMarkersDiscovered(true)}
+                    />
+                  </MarkerTooltip>
                 </motion.div>
                 <motion.div
                   key="marker-3-mobile"

--- a/src/components/vignettes/prototyping/SandboxPanel.tsx
+++ b/src/components/vignettes/prototyping/SandboxPanel.tsx
@@ -71,8 +71,6 @@ function DesignerCard({
         >
           {designer.initials}
         </div>
-        {/* Online indicator */}
-        <div className="absolute -bottom-0.5 -right-0.5 w-3 h-3 bg-emerald-400 rounded-full border-2 border-white shadow-sm" />
       </div>
 
       {/* Name and role */}
@@ -138,17 +136,8 @@ function SolutionState({
 
   return (
     <div className="w-full space-y-2">
-      {/* Main Sandbox Container - Internal Tool Dashboard Style */}
-      <div
-        className="relative rounded-xl overflow-hidden w-full"
-        data-section-id="sandbox-container"
-        style={{
-          ...getSectionHighlightStyle(1, highlightedSection),
-          background: 'linear-gradient(to bottom, #fafafa 0%, #f5f5f5 100%)',
-          boxShadow: '0 1px 3px rgba(0,0,0,0.05), 0 4px 12px rgba(0,0,0,0.04), inset 0 1px 0 rgba(255,255,255,0.8)',
-          border: '1px solid rgba(0,0,0,0.06)',
-        }}
-      >
+      {/* Outer wrapper for markers - no overflow clipping */}
+      <div className="relative">
         {/* Marker 1 - Shared library - desktop: left side, mobile: left edge */}
         <AnimatePresence>
           {!hideMarkers && (
@@ -198,7 +187,73 @@ function SolutionState({
           )}
         </AnimatePresence>
 
-        {/* App Bar Header */}
+        {/* Marker 2 - Designer homepage - desktop: right side, mobile: right edge */}
+        <AnimatePresence>
+          {!hideMarkers && (
+            <>
+              <motion.div
+                key="marker-2-desktop"
+                className="absolute -right-16 top-[140px] hidden xl:block z-20"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.2, delay: 0.05 }}
+                onMouseEnter={() => onMarkerHover?.(2)}
+                onMouseLeave={() => onMarkerHover?.(null)}
+              >
+                <MarkerTooltip
+                  number={2}
+                  text={content.designDetails[1].text}
+                  isVisible={highlightedSection === 2}
+                  side="right"
+                >
+                  <NumberedMarker
+                    number={2}
+                    onClick={() => onMarkerClick?.(2)}
+                    isActive={highlightedSection === 2}
+                    hasBeenDiscovered={markersDiscovered}
+                    onDiscover={() => setMarkersDiscovered(true)}
+                  />
+                </MarkerTooltip>
+              </motion.div>
+              <motion.div
+                key="marker-2-mobile"
+                className="absolute -right-4 top-[140px] xl:hidden z-20"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.2, delay: 0.05 }}
+              >
+                <NumberedMarker
+                  number={2}
+                  onClick={() => onMarkerClick?.(2)}
+                  isActive={highlightedSection === 2}
+                  hasBeenDiscovered={markersDiscovered}
+                  onDiscover={() => setMarkersDiscovered(true)}
+                />
+              </motion.div>
+            </>
+          )}
+        </AnimatePresence>
+
+        {/* Main Sandbox Container - Internal Tool Dashboard Style */}
+        <div
+          className="relative rounded-xl overflow-hidden w-full"
+          data-section-id="sandbox-container"
+          style={{
+            backgroundImage: highlightedSection === 1
+              ? 'none'
+              : 'linear-gradient(to bottom, #fafafa 0%, #f5f5f5 100%)',
+            backgroundColor: highlightedSection === 1
+              ? 'rgba(240, 217, 200, 0.3)'
+              : undefined,
+            boxShadow: '0 1px 3px rgba(0,0,0,0.05), 0 4px 12px rgba(0,0,0,0.04), inset 0 1px 0 rgba(255,255,255,0.8)',
+            border: '1px solid rgba(0,0,0,0.06)',
+            borderRadius: '8px',
+            transition: 'background-color 0.3s ease-in-out',
+          }}
+        >
+          {/* App Bar Header */}
         <div
           className="px-3 py-2.5 border-b border-black/[0.06]"
           style={{
@@ -240,18 +295,6 @@ function SolutionState({
             </div>
           </div>
 
-          {/* Tab navigation hint */}
-          <div className="flex items-center gap-0.5 mt-1.5 -mb-2.5">
-            <button className="px-2.5 py-1.5 text-[11px] font-medium text-neutral-800 border-b-2 border-neutral-800 -mb-px">
-              Team
-            </button>
-            <button className="px-2.5 py-1.5 text-[11px] font-medium text-neutral-400 hover:text-neutral-600 transition-colors">
-              Prototypes
-            </button>
-            <button className="px-2.5 py-1.5 text-[11px] font-medium text-neutral-400 hover:text-neutral-600 transition-colors">
-              Templates
-            </button>
-          </div>
         </div>
 
         {/* Content area - transitions between Designer Directory and Prototype Preview */}
@@ -283,55 +326,6 @@ function SolutionState({
               exit={{ opacity: 0 }}
               transition={{ duration: 0.3 }}
             >
-              {/* Marker 2 - Designer homepage - desktop: right side, mobile: right edge */}
-              <AnimatePresence>
-                {!hideMarkers && (
-                  <>
-                    <motion.div
-                      key="marker-2-desktop"
-                      className="absolute -right-16 top-4 hidden xl:block z-20"
-                      initial={{ opacity: 0 }}
-                      animate={{ opacity: 1 }}
-                      exit={{ opacity: 0 }}
-                      transition={{ duration: 0.2, delay: 0.05 }}
-                      onMouseEnter={() => onMarkerHover?.(2)}
-                      onMouseLeave={() => onMarkerHover?.(null)}
-                    >
-                      <MarkerTooltip
-                        number={2}
-                        text={content.designDetails[1].text}
-                        isVisible={highlightedSection === 2}
-                        side="right"
-                      >
-                        <NumberedMarker
-                          number={2}
-                          onClick={() => onMarkerClick?.(2)}
-                          isActive={highlightedSection === 2}
-                          hasBeenDiscovered={markersDiscovered}
-                          onDiscover={() => setMarkersDiscovered(true)}
-                        />
-                      </MarkerTooltip>
-                    </motion.div>
-                    <motion.div
-                      key="marker-2-mobile"
-                      className="absolute -right-4 top-4 xl:hidden z-20"
-                      initial={{ opacity: 0 }}
-                      animate={{ opacity: 1 }}
-                      exit={{ opacity: 0 }}
-                      transition={{ duration: 0.2, delay: 0.05 }}
-                    >
-                      <NumberedMarker
-                        number={2}
-                        onClick={() => onMarkerClick?.(2)}
-                        isActive={highlightedSection === 2}
-                        hasBeenDiscovered={markersDiscovered}
-                        onDiscover={() => setMarkersDiscovered(true)}
-                      />
-                    </motion.div>
-                  </>
-                )}
-              </AnimatePresence>
-
               {content.designers.map((designer) => (
                 <DesignerCard key={designer.id} designer={designer} />
               ))}
@@ -349,6 +343,7 @@ function SolutionState({
             </motion.div>
           )}
         </AnimatePresence>
+        </div>
         </div>
       </div>
 

--- a/src/components/vignettes/prototyping/SandboxPanel.tsx
+++ b/src/components/vignettes/prototyping/SandboxPanel.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import NumberedMarker from '../ai-highlights/NumberedMarker';
-import DesktopMarkerTooltip from '../shared/DesktopMarkerTooltip';
+import MarkerTooltip from '../shared/MarkerTooltip';
 import TerminalPanel from './TerminalPanel';
 import PrototypePreview from './PrototypePreview';
 import { useSandboxDemo } from './useSandboxDemo';
@@ -163,19 +163,20 @@ function SolutionState({
                 onMouseEnter={() => onMarkerHover?.(1)}
                 onMouseLeave={() => onMarkerHover?.(null)}
               >
-                <NumberedMarker
-                  number={1}
-                  onClick={() => onMarkerClick?.(1)}
-                  isActive={highlightedSection === 1}
-                  hasBeenDiscovered={markersDiscovered}
-                  onDiscover={() => setMarkersDiscovered(true)}
-                />
-                <DesktopMarkerTooltip
+                <MarkerTooltip
                   number={1}
                   text={content.designDetails[0].text}
                   isVisible={highlightedSection === 1}
-                  position="left"
-                />
+                  side="left"
+                >
+                  <NumberedMarker
+                    number={1}
+                    onClick={() => onMarkerClick?.(1)}
+                    isActive={highlightedSection === 1}
+                    hasBeenDiscovered={markersDiscovered}
+                    onDiscover={() => setMarkersDiscovered(true)}
+                  />
+                </MarkerTooltip>
               </motion.div>
               <motion.div
                 key="marker-1-mobile"
@@ -296,19 +297,20 @@ function SolutionState({
                       onMouseEnter={() => onMarkerHover?.(2)}
                       onMouseLeave={() => onMarkerHover?.(null)}
                     >
-                      <NumberedMarker
-                        number={2}
-                        onClick={() => onMarkerClick?.(2)}
-                        isActive={highlightedSection === 2}
-                        hasBeenDiscovered={markersDiscovered}
-                        onDiscover={() => setMarkersDiscovered(true)}
-                      />
-                      <DesktopMarkerTooltip
+                      <MarkerTooltip
                         number={2}
                         text={content.designDetails[1].text}
                         isVisible={highlightedSection === 2}
-                        position="right"
-                      />
+                        side="right"
+                      >
+                        <NumberedMarker
+                          number={2}
+                          onClick={() => onMarkerClick?.(2)}
+                          isActive={highlightedSection === 2}
+                          hasBeenDiscovered={markersDiscovered}
+                          onDiscover={() => setMarkersDiscovered(true)}
+                        />
+                      </MarkerTooltip>
                     </motion.div>
                     <motion.div
                       key="marker-2-mobile"
@@ -370,19 +372,20 @@ function SolutionState({
                 onMouseEnter={() => onMarkerHover?.(3)}
                 onMouseLeave={() => onMarkerHover?.(null)}
               >
-                <NumberedMarker
-                  number={3}
-                  onClick={() => onMarkerClick?.(3)}
-                  isActive={highlightedSection === 3}
-                  hasBeenDiscovered={markersDiscovered}
-                  onDiscover={() => setMarkersDiscovered(true)}
-                />
-                <DesktopMarkerTooltip
+                <MarkerTooltip
                   number={3}
                   text={content.designDetails[2].text}
                   isVisible={highlightedSection === 3}
-                  position="left"
-                />
+                  side="left"
+                >
+                  <NumberedMarker
+                    number={3}
+                    onClick={() => onMarkerClick?.(3)}
+                    isActive={highlightedSection === 3}
+                    hasBeenDiscovered={markersDiscovered}
+                    onDiscover={() => setMarkersDiscovered(true)}
+                  />
+                </MarkerTooltip>
               </motion.div>
               <motion.div
                 key="marker-3-mobile"

--- a/src/components/vignettes/prototyping/content.ts
+++ b/src/components/vignettes/prototyping/content.ts
@@ -61,7 +61,7 @@ export const prototypingContent: PrototypingContent = {
     },
     {
       number: 3,
-      text: 'Fork command lets you build on existing prototypes',
+      text: 'Custom slash commands make onboarding fast and easy',
     },
   ],
 
@@ -84,7 +84,7 @@ export const prototypingContent: PrototypingContent = {
     { id: 6, name: 'Taylor Brooks', initials: 'TB', avatarColor: '#14B8A6' },
   ],
   adoptionStats: {
-    designers: 12,
+    designers: 15,
     prototypes: 30,
   },
 };

--- a/src/components/vignettes/shared/DesktopMarkerTooltip.tsx
+++ b/src/components/vignettes/shared/DesktopMarkerTooltip.tsx
@@ -11,6 +11,10 @@ interface DesktopMarkerTooltipProps {
 }
 
 /**
+ * @deprecated Use MarkerTooltip instead.
+ * This component has z-index stacking issues and doesn't handle viewport boundaries.
+ * MarkerTooltip uses Radix UI for portal rendering and automatic viewport collision detection.
+ *
  * A refined tooltip that appears on desktop when hovering numbered markers.
  * Matches the portfolio's warm terracotta aesthetic with subtle animation.
  */

--- a/src/components/vignettes/shared/MarkerTooltip.tsx
+++ b/src/components/vignettes/shared/MarkerTooltip.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { ReactNode } from 'react';
+import * as Tooltip from '@radix-ui/react-tooltip';
+
+interface MarkerTooltipProps {
+  number: number;
+  text: string;
+  children: ReactNode;
+  side?: 'left' | 'right';
+  isVisible: boolean;
+}
+
+/**
+ * A viewport-aware tooltip wrapper using Radix UI.
+ * Renders tooltip in a portal to escape z-index stacking contexts.
+ * Auto-flips when near viewport edges.
+ */
+export default function MarkerTooltip({
+  number,
+  text,
+  children,
+  side = 'left',
+  isVisible,
+}: MarkerTooltipProps) {
+  return (
+    <Tooltip.Provider delayDuration={0} skipDelayDuration={0}>
+      <Tooltip.Root open={isVisible}>
+        <Tooltip.Trigger asChild>
+          {children}
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content
+            side={side}
+            sideOffset={12}
+            collisionPadding={16}
+            avoidCollisions={true}
+            className="z-[9999] hidden xl:block"
+          >
+            {/* Card styling matching DesktopMarkerTooltip */}
+            <div
+              className="relative flex items-start gap-2.5 px-3.5 py-3 bg-white rounded-lg border border-black/[0.04] w-[240px]"
+              style={{
+                boxShadow: `
+                  0 1px 2px rgba(0, 0, 0, 0.04),
+                  0 4px 12px rgba(0, 0, 0, 0.06),
+                  0 0 0 1px rgba(138, 85, 48, 0.04)
+                `,
+              }}
+            >
+              {/* Number badge - matches the marker style */}
+              <div className="flex items-center justify-center flex-shrink-0 size-5 rounded-full bg-transparent border border-accent-300 text-accent-600 text-[10px] font-semibold mt-px">
+                {number}
+              </div>
+              {/* Text content */}
+              <p
+                className="text-[14px] leading-[1.5] tracking-[-0.01em] text-neutral-800 m-0"
+                style={{ fontFamily: 'var(--font-inter), system-ui, sans-serif' }}
+              >
+                {text}
+              </p>
+            </div>
+            {/* Arrow */}
+            <Tooltip.Arrow
+              className="fill-white"
+              style={{ filter: 'drop-shadow(0 1px 1px rgba(0,0,0,0.04))' }}
+              width={12}
+              height={6}
+            />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
- Fix tooltip z-index stacking and viewport overflow issues across all vignette panels
- Fix Design Sandbox markers being clipped by overflow-hidden container
- Update tooltip #3 text to "Custom slash commands make onboarding fast and easy"
- Remove tab navigation and online indicator dots from Design Sandbox
- Update designer count from 12 to 15

## Test plan
- [ ] Navigate to homepage and scroll through vignettes
- [ ] Verify all 3 numbered markers are visible on Design Sandbox (xl+ viewport)
- [ ] Hover over each marker and confirm tooltips appear with correct z-index
- [ ] Verify tooltips don't overflow viewport edges
- [ ] Confirm tooltip #3 shows updated text about slash commands
- [ ] Test on mobile - tap markers to open the mobile sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)