### PR TITLE
Add simplified interaction tracking for vignettes

### DIFF
--- a/src/components/vignettes/VignetteContainer.tsx
+++ b/src/components/vignettes/VignetteContainer.tsx
@@ -1,14 +1,16 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
+import { useInView } from 'react-intersection-observer';
 import { fadeInUp } from '@/lib/animations';
+import { trackVignetteViewed, type VignetteId } from '@/lib/analytics';
 
 interface VignetteContainerProps {
   title?: string;
   subtitle?: string;
   children: ReactNode;
-  id: string;
+  id: VignetteId;
   allowOverflow?: boolean;
   className?: string;
 }
@@ -21,8 +23,22 @@ export default function VignetteContainer({
   allowOverflow = false,
   className = ''
 }: VignetteContainerProps) {
+  const hasTrackedView = useRef(false);
+  const { ref, inView } = useInView({
+    threshold: 0.3,
+    triggerOnce: true,
+  });
+
+  useEffect(() => {
+    if (inView && !hasTrackedView.current) {
+      hasTrackedView.current = true;
+      trackVignetteViewed(id);
+    }
+  }, [inView, id]);
+
   return (
     <motion.article
+      ref={ref}
       id={id}
       className={`w-full h-full ${
         allowOverflow ? 'overflow-visible' : 'overflow-hidden'

--- a/src/components/vignettes/ai-highlights/AIHighlightsVignette.tsx
+++ b/src/components/vignettes/ai-highlights/AIHighlightsVignette.tsx
@@ -9,6 +9,7 @@ import VignetteContainer from '@/components/vignettes/VignetteContainer';
 import VignetteSplit from '@/components/vignettes/VignetteSplit';
 import { useScrollToSection } from '@/components/vignettes/shared/useScrollToSection';
 import { fadeInUp } from '@/lib/animations';
+import { trackDesignDetailViewed } from '@/lib/analytics';
 
 // Hook to detect mobile viewport
 function useIsMobile() {
@@ -38,8 +39,16 @@ export default function AIHighlightsVignette() {
   const [sheetOpen, setSheetOpen] = useState(false);
   const [sheetIndex, setSheetIndex] = useState(0);
   const clearTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const viewedDetailsRef = useRef<Set<number>>(new Set());
   const isMobile = useIsMobile();
   const { scrollToSection } = useScrollToSection();
+
+  const trackDetailIfNew = useCallback((detailNumber: number) => {
+    if (!viewedDetailsRef.current.has(detailNumber)) {
+      viewedDetailsRef.current.add(detailNumber);
+      trackDesignDetailViewed('ai-highlights', detailNumber);
+    }
+  }, []);
 
   // Handle number click (mobile only - opens sheet)
   const handleNumberClick = useCallback(
@@ -55,12 +64,13 @@ export default function AIHighlightsVignette() {
       setSheetIndex(number - 1); // Convert 1-based to 0-based index
       setSheetOpen(true);
       setActiveNumber(number);
+      trackDetailIfNew(number);
       // Scroll after a brief delay to let sheet animate in
       setTimeout(() => {
         scrollToSection(sectionMap[number]);
       }, 100);
     },
-    [isMobile, scrollToSection]
+    [isMobile, scrollToSection, trackDetailIfNew]
   );
 
   // Handle hover (desktop only - highlights)
@@ -74,8 +84,11 @@ export default function AIHighlightsVignette() {
       }
 
       setActiveNumber(number);
+      if (number !== null) {
+        trackDetailIfNew(number);
+      }
     },
-    [isMobile]
+    [isMobile, trackDetailIfNew]
   );
 
   // Handle sheet close
@@ -90,6 +103,7 @@ export default function AIHighlightsVignette() {
       setSheetIndex(index);
       const number = index + 1; // Convert 0-based to 1-based
       setActiveNumber(number);
+      trackDetailIfNew(number);
 
       // Scroll to center element in visible area above sheet
       const sectionId = sectionMap[number];
@@ -97,7 +111,7 @@ export default function AIHighlightsVignette() {
         scrollToSection(sectionId);
       }
     },
-    [scrollToSection]
+    [scrollToSection, trackDetailIfNew]
   );
 
   // Cleanup timeout on unmount

--- a/src/components/vignettes/ai-highlights/HighlightsTextPanel.tsx
+++ b/src/components/vignettes/ai-highlights/HighlightsTextPanel.tsx
@@ -30,7 +30,7 @@ export default function HighlightsTextPanel() {
       )}
 
       {/* Process notes */}
-      <ProcessNotes notes={aiHighlightsContent.processNotes} />
+      <ProcessNotes notes={aiHighlightsContent.processNotes} vignetteId="ai-highlights" />
     </div>
   );
 }

--- a/src/components/vignettes/ai-suggestions/SuggestionsTextPanel.tsx
+++ b/src/components/vignettes/ai-suggestions/SuggestionsTextPanel.tsx
@@ -30,7 +30,7 @@ export default function SuggestionsTextPanel() {
       )}
 
       {/* Process notes */}
-      <ProcessNotes notes={aiSuggestionsContent.processNotes} />
+      <ProcessNotes notes={aiSuggestionsContent.processNotes} vignetteId="ai-suggestions" />
     </div>
   );
 }

--- a/src/components/vignettes/home-connect/HomeConnectTextPanel.tsx
+++ b/src/components/vignettes/home-connect/HomeConnectTextPanel.tsx
@@ -30,7 +30,7 @@ export default function HomeConnectTextPanel() {
       )}
 
       {/* Process notes */}
-      <ProcessNotes notes={homeConnectContent.processNotes} />
+      <ProcessNotes notes={homeConnectContent.processNotes} vignetteId="home-connect" />
     </div>
   );
 }

--- a/src/components/vignettes/home-connect/HomeConnectVignette.tsx
+++ b/src/components/vignettes/home-connect/HomeConnectVignette.tsx
@@ -9,6 +9,7 @@ import VignetteContainer from '@/components/vignettes/VignetteContainer';
 import VignetteSplit from '@/components/vignettes/VignetteSplit';
 import { useScrollToSection } from '@/components/vignettes/shared/useScrollToSection';
 import { fadeInUp } from '@/lib/animations';
+import { trackDesignDetailViewed } from '@/lib/analytics';
 
 // Hook to detect mobile viewport
 function useIsMobile() {
@@ -38,8 +39,16 @@ export default function HomeConnectVignette() {
   const [sheetOpen, setSheetOpen] = useState(false);
   const [sheetIndex, setSheetIndex] = useState(0);
   const clearTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const viewedDetailsRef = useRef<Set<number>>(new Set());
   const isMobile = useIsMobile();
   const { scrollToSection } = useScrollToSection();
+
+  const trackDetailIfNew = useCallback((detailNumber: number) => {
+    if (!viewedDetailsRef.current.has(detailNumber)) {
+      viewedDetailsRef.current.add(detailNumber);
+      trackDesignDetailViewed('home-connect', detailNumber);
+    }
+  }, []);
 
   // Handle number click (mobile only - opens sheet)
   const handleNumberClick = useCallback(
@@ -55,12 +64,13 @@ export default function HomeConnectVignette() {
       setSheetIndex(number - 1); // Convert 1-based to 0-based index
       setSheetOpen(true);
       setActiveNumber(number);
+      trackDetailIfNew(number);
       // Scroll after a brief delay to let sheet animate in
       setTimeout(() => {
         scrollToSection(sectionMap[number]);
       }, 100);
     },
-    [isMobile, scrollToSection]
+    [isMobile, scrollToSection, trackDetailIfNew]
   );
 
   // Handle hover (desktop only - highlights)
@@ -74,8 +84,11 @@ export default function HomeConnectVignette() {
       }
 
       setActiveNumber(number);
+      if (number !== null) {
+        trackDetailIfNew(number);
+      }
     },
-    [isMobile]
+    [isMobile, trackDetailIfNew]
   );
 
   // Handle sheet close
@@ -90,6 +103,7 @@ export default function HomeConnectVignette() {
       setSheetIndex(index);
       const number = index + 1; // Convert 0-based to 1-based
       setActiveNumber(number);
+      trackDetailIfNew(number);
 
       // Scroll to center element in visible area above sheet
       const sectionId = sectionMap[number];
@@ -97,7 +111,7 @@ export default function HomeConnectVignette() {
         scrollToSection(sectionId);
       }
     },
-    [scrollToSection]
+    [scrollToSection, trackDetailIfNew]
   );
 
   // Cleanup timeout on unmount

--- a/src/components/vignettes/multilingual/MultilingualTextPanel.tsx
+++ b/src/components/vignettes/multilingual/MultilingualTextPanel.tsx
@@ -30,7 +30,7 @@ export default function MultilingualTextPanel() {
       )}
 
       {/* Process notes */}
-      <ProcessNotes notes={multilingualContent.processNotes} />
+      <ProcessNotes notes={multilingualContent.processNotes} vignetteId="multilingual" />
     </div>
   );
 }

--- a/src/components/vignettes/prototyping/PrototypingTextPanel.tsx
+++ b/src/components/vignettes/prototyping/PrototypingTextPanel.tsx
@@ -30,7 +30,7 @@ export default function PrototypingTextPanel() {
       )}
 
       {/* Process notes */}
-      <ProcessNotes notes={prototypingContent.processNotes} />
+      <ProcessNotes notes={prototypingContent.processNotes} vignetteId="prototyping" />
     </div>
   );
 }

--- a/src/components/vignettes/prototyping/PrototypingVignette.tsx
+++ b/src/components/vignettes/prototyping/PrototypingVignette.tsx
@@ -9,6 +9,7 @@ import VignetteContainer from '@/components/vignettes/VignetteContainer';
 import VignetteSplit from '@/components/vignettes/VignetteSplit';
 import { useScrollToSection } from '@/components/vignettes/shared/useScrollToSection';
 import { fadeInUp } from '@/lib/animations';
+import { trackDesignDetailViewed } from '@/lib/analytics';
 import { prototypingContent } from './content';
 
 // Hook to detect mobile viewport
@@ -39,8 +40,16 @@ export default function PrototypingVignette() {
   const [sheetOpen, setSheetOpen] = useState(false);
   const [sheetIndex, setSheetIndex] = useState(0);
   const clearTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const viewedDetailsRef = useRef<Set<number>>(new Set());
   const isMobile = useIsMobile();
   const { scrollToSection } = useScrollToSection();
+
+  const trackDetailIfNew = useCallback((detailNumber: number) => {
+    if (!viewedDetailsRef.current.has(detailNumber)) {
+      viewedDetailsRef.current.add(detailNumber);
+      trackDesignDetailViewed('prototyping', detailNumber);
+    }
+  }, []);
 
   // Handle number click (mobile only - opens sheet)
   const handleNumberClick = useCallback(
@@ -56,12 +65,13 @@ export default function PrototypingVignette() {
       setSheetIndex(number - 1); // Convert 1-based to 0-based index
       setSheetOpen(true);
       setActiveNumber(number);
+      trackDetailIfNew(number);
       // Scroll after a brief delay to let sheet animate in
       setTimeout(() => {
         scrollToSection(sectionMap[number]);
       }, 100);
     },
-    [isMobile, scrollToSection]
+    [isMobile, scrollToSection, trackDetailIfNew]
   );
 
   // Handle hover (desktop only - highlights)
@@ -75,8 +85,11 @@ export default function PrototypingVignette() {
       }
 
       setActiveNumber(number);
+      if (number !== null) {
+        trackDetailIfNew(number);
+      }
     },
-    [isMobile]
+    [isMobile, trackDetailIfNew]
   );
 
   // Handle sheet close
@@ -91,6 +104,7 @@ export default function PrototypingVignette() {
       setSheetIndex(index);
       const number = index + 1; // Convert 0-based to 1-based
       setActiveNumber(number);
+      trackDetailIfNew(number);
 
       // Scroll to center element in visible area above sheet
       const sectionId = sectionMap[number];
@@ -98,7 +112,7 @@ export default function PrototypingVignette() {
         scrollToSection(sectionId);
       }
     },
-    [scrollToSection]
+    [scrollToSection, trackDetailIfNew]
   );
 
   // Cleanup timeout on unmount

--- a/src/components/vignettes/shared/MobileDesignNotesSheet.tsx
+++ b/src/components/vignettes/shared/MobileDesignNotesSheet.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence, PanInfo } from 'framer-motion';
 import type { DesignNote } from '@/components/vignettes/types';
-import { trackDesignNoteViewed, type VignetteId } from '@/lib/analytics';
+import { type VignetteId } from '@/lib/analytics';
 
 interface MobileDesignNotesSheetProps {
   isOpen: boolean;
@@ -26,21 +26,12 @@ export function MobileDesignNotesSheet({
   const currentNote = notes[currentIndex];
   const [isDragging, setIsDragging] = useState(false);
   const [mounted, setMounted] = useState(false);
-  const trackedNotesRef = useRef<Set<string>>(new Set());
 
   // Track mount state for portal (SSR safety)
   useEffect(() => {
     setMounted(true);
     return () => setMounted(false);
   }, []);
-
-  // Track design note views (only once per note per session)
-  useEffect(() => {
-    if (isOpen && currentNote && !trackedNotesRef.current.has(currentNote.id)) {
-      trackDesignNoteViewed(vignetteId, currentNote.id);
-      trackedNotesRef.current.add(currentNote.id);
-    }
-  }, [isOpen, currentNote, vignetteId]);
 
   // Keyboard navigation
   useEffect(() => {

--- a/src/components/vignettes/shared/ProcessNotes.tsx
+++ b/src/components/vignettes/shared/ProcessNotes.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { trackProcessNotesExpanded, type VignetteId } from '@/lib/analytics';
 
 interface ProcessNotesProps {
   notes: string[];
+  vignetteId: VignetteId;
 }
 
 function ChevronIcon({ className }: { className?: string }) {
@@ -28,15 +30,25 @@ function ChevronIcon({ className }: { className?: string }) {
   );
 }
 
-export default function ProcessNotes({ notes }: ProcessNotesProps) {
+export default function ProcessNotes({ notes, vignetteId }: ProcessNotesProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const hasTrackedExpansion = useRef(false);
 
   if (notes.length === 0) return null;
+
+  const handleToggle = () => {
+    const newExpanded = !isExpanded;
+    setIsExpanded(newExpanded);
+    if (newExpanded && !hasTrackedExpansion.current) {
+      hasTrackedExpansion.current = true;
+      trackProcessNotesExpanded(vignetteId);
+    }
+  };
 
   return (
     <div className="mt-6">
       <button
-        onClick={() => setIsExpanded(!isExpanded)}
+        onClick={handleToggle}
         className="btn-interactive btn-secondary text-sm font-[family-name:var(--font-inter)]"
       >
         Design process notes

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -8,19 +8,22 @@ export type VignetteId =
   | 'home-connect'
   | 'vibe-coding';
 
-export type VignetteStage = 'solution' | 'designNotes';
-
-export function trackVignetteInteracted(vignetteId: VignetteId, stage: VignetteStage) {
-  posthog.capture('vignette_interacted', {
+export function trackVignetteViewed(vignetteId: VignetteId) {
+  posthog.capture('vignette_viewed', {
     vignette_id: vignetteId,
-    stage,
   });
 }
 
-export function trackDesignNoteViewed(vignetteId: VignetteId, noteId: string) {
-  posthog.capture('design_note_viewed', {
+export function trackDesignDetailViewed(vignetteId: VignetteId, detailNumber: number) {
+  posthog.capture('design_detail_viewed', {
     vignette_id: vignetteId,
-    note_id: noteId,
+    detail_number: detailNumber,
+  });
+}
+
+export function trackProcessNotesExpanded(vignetteId: VignetteId) {
+  posthog.capture('process_notes_expanded', {
+    vignette_id: vignetteId,
   });
 }
 

--- a/src/lib/vignette-stage-context.tsx
+++ b/src/lib/vignette-stage-context.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { createContext, useContext, useState, useCallback, ReactNode } from 'react';
-import { trackVignetteInteracted, type VignetteId } from './analytics';
+import { type VignetteId } from './analytics';
 
 // 'loading' is used by AI vignettes for auto-play loading animation
 export type VignetteStage = 'loading' | 'solution' | 'designNotes';
@@ -35,13 +35,11 @@ export function VignetteStageProvider({
 
   const goToSolution = useCallback(() => {
     setStage('solution');
-    trackVignetteInteracted(vignetteId, 'solution');
-  }, [setStage, vignetteId]);
+  }, [setStage]);
 
   const goToDesignNotes = useCallback(() => {
     setStage('designNotes');
-    trackVignetteInteracted(vignetteId, 'designNotes');
-  }, [setStage, vignetteId]);
+  }, [setStage]);
 
   return (
     <VignetteStageContext.Provider


### PR DESCRIPTION
Replace old staged-flow tracking with new event system:
- vignette_viewed: fires when vignette scrolls into viewport (30% threshold)
- design_detail_viewed: fires on marker hover (desktop) or sheet view (mobile)
- process_notes_expanded: fires when design process notes dropdown opens

All events are deduplicated per session using refs. Tracking is now
integrated directly into vignette components rather than relying on
the unused VignetteStageContext.