### PR TITLE
Add scroll-to-skip functionality for intro sequence

### DIFF
--- a/src/components/vignettes/hero/HeroVignette.tsx
+++ b/src/components/vignettes/hero/HeroVignette.tsx
@@ -29,7 +29,14 @@ export default function HeroVignette() {
   const isMobile = useIsMobile();
   const t = reducedMotion ? timingReduced : timing;
   const [isSplash, setIsSplash] = useState(!reducedMotion);
-  const { setSplashComplete, setStage } = useIntroSequence();
+  const { setSplashComplete, setStage, isComplete } = useIntroSequence();
+
+  // Snap to final state if intro was skipped (via scroll)
+  useEffect(() => {
+    if (isComplete && isSplash) {
+      setIsSplash(false);
+    }
+  }, [isComplete, isSplash]);
 
   // Transition from splash to normal layout
   useEffect(() => {
@@ -38,6 +45,9 @@ export default function HeroVignette() {
       setStage('complete');
       return;
     }
+
+    // Don't set timers if already complete (skipped)
+    if (isComplete) return;
 
     // End splash state
     const splashTimer = setTimeout(() => {
@@ -53,7 +63,7 @@ export default function HeroVignette() {
       clearTimeout(splashTimer);
       clearTimeout(transitionTimer);
     };
-  }, [reducedMotion, t, setSplashComplete, setStage]);
+  }, [reducedMotion, t, setSplashComplete, setStage, isComplete]);
 
   return (
     <motion.section


### PR DESCRIPTION
## Summary
This PR adds the ability for users to skip the intro sequence by scrolling, improving the user experience for those who want to quickly access the main content.

## Key Changes
- **IntroSequenceContext**: Added scroll detection that triggers intro skip when user scrolls more than 20 pixels
  - New `skipIntro()` function that sets stage to 'complete' and marks splash as complete
  - New `useEffect` hook that listens for scroll events with passive listener for performance
  - Exported `skipIntro` function in context value
  
- **HeroVignette**: Updated to handle intro skip state gracefully
  - Added `isComplete` to destructured context values
  - New `useEffect` that snaps splash state to false when intro is skipped
  - Added guard clause to prevent setting timers when intro is already complete
  - Updated dependency array to include `isComplete`

## Implementation Details
- Scroll threshold set to 20 pixels to avoid accidental skips from minor scrolling
- Scroll listener uses `passive: true` flag for better scroll performance
- Skip logic only activates when stage is not already 'complete' to prevent redundant operations
- Gracefully handles the case where user scrolls during the intro animation sequence

https://claude.ai/code/session_01PAwKF6CKKqn9mQcx63fnWp